### PR TITLE
Implement SP1-103 main function skeleton

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,3 @@
 export(hello)
 
+export(estimate_parametric_hrf)

--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -1,0 +1,107 @@
+#' Estimate parametric HRF parameters
+#'
+#' Main user-facing function that performs parameteric HRF estimation. This
+#' implementation only performs argument validation and resolution of HRF
+#' interfaces.  The fitting engine itself will be implemented in later tickets.
+#'
+#' @param fmri_data fMRI dataset object (placeholder in this sprint)
+#' @param event_model Event model describing stimulus timing
+#' @param parametric_hrf Parametric HRF model name, currently only "lwu" supported
+#' @param theta_seed Numeric vector of initial parameter values or `NULL`
+#' @param theta_bounds List with elements `lower` and `upper` or `NULL`
+#' @param confound_formula Optional formula specifying confound regressors
+#' @param baseline_model Baseline model specification
+#' @param hrf_eval_times Optional numeric vector of HRF evaluation time points
+#' @param hrf_span Positive numeric giving default HRF evaluation span in seconds
+#' @param lambda_ridge Ridge penalty applied in the fitting engine
+#' @param mask Optional mask for spatial subsetting
+#' @param verbose Logical; print progress messages
+#'
+#' @return A placeholder object containing the validated arguments
+#' @export
+estimate_parametric_hrf <- function(
+  fmri_data,
+  event_model,
+  parametric_hrf = "lwu",
+  theta_seed = NULL,
+  theta_bounds = NULL,
+  confound_formula = NULL,
+  baseline_model = "intercept",
+  hrf_eval_times = NULL,
+  hrf_span = 30,
+  lambda_ridge = 0.01,
+  mask = NULL,
+  verbose = FALSE
+) {
+  assertthat::assert_that(!missing(fmri_data), !missing(event_model))
+  assertthat::assert_that(is.character(parametric_hrf), length(parametric_hrf) == 1)
+  parametric_hrf <- tolower(parametric_hrf)
+
+  if (identical(parametric_hrf, "lwu")) {
+    hrf_interface <- list(
+      hrf_function = .lwu_hrf_function,
+      taylor_basis = .lwu_hrf_taylor_basis_function,
+      parameter_names = .lwu_hrf_parameter_names(),
+      default_seed = .lwu_hrf_default_seed(),
+      default_bounds = .lwu_hrf_default_bounds()
+    )
+  } else {
+    stop("Unsupported parametric_hrf: ", parametric_hrf, call. = FALSE)
+  }
+
+  if (is.null(theta_seed)) {
+    theta_seed <- hrf_interface$default_seed
+  } else {
+    assertthat::assert_that(
+      is.numeric(theta_seed),
+      length(theta_seed) == length(hrf_interface$parameter_names),
+      msg = "theta_seed must be numeric and match number of parameters"
+    )
+  }
+
+  if (is.null(theta_bounds)) {
+    theta_bounds <- hrf_interface$default_bounds
+  } else {
+    assertthat::assert_that(
+      is.list(theta_bounds),
+      all(c("lower", "upper") %in% names(theta_bounds)),
+      is.numeric(theta_bounds$lower),
+      is.numeric(theta_bounds$upper),
+      length(theta_bounds$lower) == length(hrf_interface$parameter_names),
+      length(theta_bounds$upper) == length(hrf_interface$parameter_names),
+      msg = "theta_bounds must be a list with numeric 'lower' and 'upper' vectors"
+    )
+  }
+
+  assertthat::assert_that(all(theta_bounds$lower < theta_bounds$upper),
+                          msg = "theta_bounds 'lower' must be less than 'upper'")
+  assertthat::assert_that(all(theta_seed >= theta_bounds$lower),
+                          all(theta_seed <= theta_bounds$upper),
+                          msg = "theta_seed must fall within theta_bounds")
+
+  if (!is.null(hrf_eval_times)) {
+    assertthat::assert_that(is.numeric(hrf_eval_times), all(hrf_eval_times >= 0))
+  }
+  assertthat::assert_that(is.numeric(hrf_span), length(hrf_span) == 1, hrf_span > 0)
+  assertthat::assert_that(is.numeric(lambda_ridge), length(lambda_ridge) == 1, lambda_ridge >= 0)
+  assertthat::assert_that(is.logical(verbose), length(verbose) == 1)
+
+  result <- list(
+    fmri_data = fmri_data,
+    event_model = event_model,
+    parametric_hrf = parametric_hrf,
+    theta_seed = theta_seed,
+    theta_bounds = theta_bounds,
+    confound_formula = confound_formula,
+    baseline_model = baseline_model,
+    hrf_eval_times = hrf_eval_times,
+    hrf_span = hrf_span,
+    lambda_ridge = lambda_ridge,
+    mask = mask,
+    verbose = verbose,
+    hrf_interface = hrf_interface
+  )
+  class(result) <- "parametric_hrf_fit_placeholder"
+  result
+}
+

--- a/tests/testthat/test-estimate-parametric-hrf.R
+++ b/tests/testthat/test-estimate-parametric-hrf.R
@@ -1,0 +1,31 @@
+library(testthat)
+library(fmriparametric)
+
+context("estimate_parametric_hrf input validation")
+
+# simple placeholder objects
+data_obj <- "fmri_data"
+event_obj <- "event_model"
+
+
+test_that("defaults are applied when theta_seed and bounds are NULL", {
+  res <- estimate_parametric_hrf(data_obj, event_obj)
+  expect_equal(res$theta_seed, c(6, 2.5, 0.35))
+  expect_true(is.list(res$theta_bounds))
+})
+
+test_that("unsupported hrf model errors", {
+  expect_error(estimate_parametric_hrf(data_obj, event_obj, parametric_hrf = "bad"))
+})
+
+test_that("theta_seed length validated", {
+  expect_error(estimate_parametric_hrf(data_obj, event_obj, theta_seed = c(1,2)))
+})
+
+test_that("theta_bounds structure validated", {
+  expect_error(estimate_parametric_hrf(data_obj, event_obj, theta_bounds = list(lower = c(1,2,3))))
+})
+
+test_that("verbose must be logical", {
+  expect_error(estimate_parametric_hrf(data_obj, event_obj, verbose = "yes"))
+})


### PR DESCRIPTION
## Summary
- add `estimate_parametric_hrf()` with argument validation and HRF resolution
- export the new function
- create unit tests for validation behaviour

## Testing
- `R CMD build .` *(fails: command not found)*
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b1567419c832d9f3ec2d0f51730cd