### PR TITLE
Implement SP1-108 basic S3 methods

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,7 @@
 export(hello)
 
 export(estimate_parametric_hrf)
+
+S3method(print,parametric_hrf_fit)
+S3method(coef,parametric_hrf_fit)
+S3method(summary,parametric_hrf_fit)

--- a/R/parametric-hrf-fit-methods.R
+++ b/R/parametric-hrf-fit-methods.R
@@ -1,0 +1,48 @@
+#' Print a parametric_hrf_fit object
+#'
+#' Displays a concise summary of the fit including the HRF model,
+#' number of voxels and basic parameter statistics.
+#'
+#' @param x An object of class `parametric_hrf_fit`.
+#' @param ... Additional arguments passed to methods. Ignored.
+#' @return The input object `x` invisibly.
+#' @export
+print.parametric_hrf_fit <- function(x, ...) {
+  cat("Parametric HRF Fit\n")
+  cat("Model:", x$hrf_model, "\n")
+  cat("Voxels:", nrow(x$estimated_parameters), "\n")
+  cat("\nParameter Summary:\n")
+  print(summary(x$estimated_parameters))
+  invisible(x)
+}
+
+#' Extract coefficients from a parametric_hrf_fit object
+#'
+#' Returns the matrix of estimated HRF parameters for each voxel.
+#'
+#' @param object An object of class `parametric_hrf_fit`.
+#' @param ... Additional arguments passed to methods. Ignored.
+#' @return Numeric matrix of parameter estimates.
+#' @export
+coef.parametric_hrf_fit <- function(object, ...) {
+  object$estimated_parameters
+}
+
+#' Summarize a parametric_hrf_fit object
+#'
+#' Produces summary statistics of the estimated parameters and amplitudes.
+#'
+#' @param object An object of class `parametric_hrf_fit`.
+#' @param ... Additional arguments passed to methods. Ignored.
+#' @return A list with parameter and amplitude summaries.
+#' @export
+summary.parametric_hrf_fit <- function(object, ...) {
+  param_sum <- apply(object$estimated_parameters, 2, summary)
+  amp_sum <- summary(object$amplitudes)
+  list(
+    parameter_summary = param_sum,
+    amplitude_summary = amp_sum,
+    hrf_model = object$hrf_model,
+    n_voxels = n_voxels(object)
+  )
+}

--- a/tests/testthat/test-parametric-hrf-fit-methods.R
+++ b/tests/testthat/test-parametric-hrf-fit-methods.R
@@ -1,0 +1,28 @@
+library(fmriparametric)
+library(testthat)
+
+context("parametric_hrf_fit S3 methods")
+
+pars <- matrix(rep(1:3, each = 2), nrow = 2, byrow = TRUE)
+amps <- c(1, 2)
+obj <- new_parametric_hrf_fit(
+  estimated_parameters = pars,
+  amplitudes = amps,
+  parameter_names = c("tau", "sigma", "rho"),
+  metadata = list(n_timepoints = 10)
+)
+
+test_that("print method produces output", {
+  expect_output(print(obj), "Parametric HRF Fit")
+})
+
+test_that("coef method returns matrix", {
+  expect_equal(coef(obj), pars)
+})
+
+test_that("summary method returns list with summaries", {
+  s <- summary(obj)
+  expect_true(is.list(s))
+  expect_true("parameter_summary" %in% names(s))
+  expect_true("amplitude_summary" %in% names(s))
+})


### PR DESCRIPTION
## Summary
- implement print, coef and summary S3 methods for `parametric_hrf_fit`
- register S3 methods in `NAMESPACE`
- add tests for the new S3 methods

## Testing
- `R CMD check` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b1b3917b0832da6b7c5027e8b7992