### PR TITLE
Fix rho derivative in SIMD Taylor

### DIFF
--- a/R/performance_enhancements.R
+++ b/R/performance_enhancements.R
@@ -243,7 +243,8 @@
   # Derivatives (vectorized operations)
   dh_dtau <- h_base * z / sigma0
   dh_dsigma <- h_base * z_squared / sigma0
-  dh_drho <- rep(0, length(t))  # Simplified for LWU main component
+  z_u <- (t - tau0 - 2 * sigma0) / (1.6 * sigma0)
+  dh_drho <- -exp(-0.5 * z_u * z_u)
   
   # Linear combination (SIMD-optimized)
   h_taylor <- h_base + dtau * dh_dtau + dsigma * dh_dsigma + drho * dh_drho

--- a/R/performance_optimizations.R
+++ b/R/performance_optimizations.R
@@ -161,7 +161,8 @@
   # Derivatives (compiler can vectorize)
   dh_dt1 <- h0 * z1 / theta0[2]
   dh_dt2 <- h0 * z1 * z1 / theta0[2]
-  dh_dt3 <- numeric(n)  # Placeholder
+  z_u <- (t - theta0[1] - 2 * theta0[2]) / (1.6 * theta0[2])
+  dh_dt3 <- -exp(-0.5 * z_u * z_u)
   
   # Linear combination (SIMD-friendly)
   h <- h0 + dt1 * dh_dt1 + dt2 * dh_dt2 + dt3 * dh_dt3

--- a/tests/testthat/test-simd-rho-recovery.R
+++ b/tests/testthat/test-simd-rho-recovery.R
@@ -1,0 +1,44 @@
+context("SIMD Taylor rho derivative")
+
+test_that("rho parameter can be recovered with SIMD Taylor basis", {
+  set.seed(123)
+  n_time <- 60
+  t_hrf <- seq(0, 30, length.out = 61)
+  true_theta <- c(6, 2.5, 0.35)
+
+  S <- matrix(0, nrow = n_time, ncol = 1)
+  S[seq(10, n_time, by = 20), 1] <- 1
+
+  true_hrf <- exp(-(t_hrf - true_theta[1])^2 / (2 * true_theta[2]^2)) -
+    true_theta[3] * exp(-(t_hrf - true_theta[1] - 2 * true_theta[2])^2 /
+                         (2 * (1.6 * true_theta[2])^2))
+  conv_full <- convolve(S[, 1], rev(true_hrf), type = "open")
+  Y <- matrix(conv_full[1:n_time] + rnorm(n_time, sd = 0.05), ncol = 1)
+
+  taylor_basis_simd <- function(theta0, t) {
+    z1 <- (t - theta0[1]) / theta0[2]
+    h0 <- exp(-0.5 * z1 * z1)
+    dh_dt1 <- h0 * z1 / theta0[2]
+    dh_dt2 <- h0 * z1 * z1 / theta0[2]
+    z_u <- (t - theta0[1] - 2 * theta0[2]) / (1.6 * theta0[2])
+    dh_dt3 <- -exp(-0.5 * z_u * z_u)
+    cbind(h0, dh_dt1, dh_dt2, dh_dt3)
+  }
+
+  hrf_iface <- list(
+    taylor_basis = taylor_basis_simd,
+    parameter_names = c("tau", "sigma", "rho")
+  )
+
+  fit <- .parametric_engine(
+    Y_proj = Y,
+    S_target_proj = S,
+    scan_times = seq_len(n_time),
+    hrf_eval_times = t_hrf,
+    hrf_interface = hrf_iface,
+    theta_seed = c(6, 2.5, 0.1),
+    theta_bounds = list(lower = c(0, 0.05, 0), upper = c(20, 10, 1.5))
+  )
+
+  expect_lt(abs(fit$theta_hat[1, 3] - true_theta[3]), 0.1)
+})


### PR DESCRIPTION
## Summary
- implement analytic derivative wrt rho for SIMD Taylor helper
- update SIMD HRF helper accordingly
- add regression test to ensure rho is recoverable

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca6129780832da04f2e3c6f039aac