### PR TITLE
Unify API and remove dead code

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,10 +3,7 @@ useDynLib(fmriparametry, .registration=TRUE)
 
 export(hello)
 export(estimate_parametric_hrf)
-export(estimate_parametric_hrf_v2)
-export(estimate_parametric_hrf_v3)
-export(estimate_parametric_hrf_rock_solid)
-export(estimate_parametric_hrf_ultimate)
+export(fmriparametric_api_version)
 
 S3method(print,parametric_hrf_fit)
 S3method(coef,parametric_hrf_fit)

--- a/R/api-version.R
+++ b/R/api-version.R
@@ -1,0 +1,8 @@
+#' Public API version
+#'
+#' This string indicates the semantic version of the exported API
+#' for compatibility checks.
+#'
+#' @export
+fmriparametric_api_version <- "0.2.0"
+

--- a/R/consolidation_plan.R
+++ b/R/consolidation_plan.R
@@ -17,7 +17,7 @@
 #' - Parallel processing (Sprint 3)
 #' - Comprehensive diagnostics
 #'
-#' @export
+#' @keywords internal
 estimate_parametric_hrf_ultimate <- function(
   fmri_data,
   event_model,

--- a/R/parametric-engine-optimized.R
+++ b/R/parametric-engine-optimized.R
@@ -49,9 +49,6 @@
   validate = TRUE
 ) {
   
-  # Load engineering standards
-  source(file.path(dirname(getwd()), "R", "engineering-standards.R"), local = TRUE)
-  
   # Start timing
   total_time <- system.time({
     

--- a/R/parametric-hrf-fit-methods-v3.R
+++ b/R/parametric-hrf-fit-methods-v3.R
@@ -260,7 +260,6 @@ plot.parametric_hrf_fit <- function(x,
   
   # Load HRF function
   if (x$hrf_model == "lwu") {
-    source(system.file("R", "hrf-interface-lwu.R", package = "fmriparametric"), local = TRUE)
     hrf_fn <- .lwu_hrf_function
   }
   

--- a/R/rock-solid-recovery.R
+++ b/R/rock-solid-recovery.R
@@ -106,9 +106,6 @@
   # Level 1: Try full iterative estimation
   result <- .try_with_recovery(
     primary_fn = function() {
-      source(file.path(dirname(getwd()), "R", "parametric-engine-iterative.R"), 
-             local = TRUE)
-      
       .parametric_engine_iterative(
         Y_proj = Y_proj,
         S_target_proj = S_target_proj,
@@ -132,9 +129,6 @@
   # Level 2: Try single-pass estimation
   result <- .try_with_recovery(
     primary_fn = function() {
-      source(file.path(dirname(getwd()), "R", "parametric-engine.R"), 
-             local = TRUE)
-      
       basic_result <- .parametric_engine(
         Y_proj = Y_proj,
         S_target_proj = S_target_proj,

--- a/R/test_compatibility_layer.R
+++ b/R/test_compatibility_layer.R
@@ -265,3 +265,28 @@ set_engineering_options <- function(verbose = FALSE, validate = TRUE,
 
 # Utility operator
 `%||%` <- function(x, y) if (is.null(x)) y else x
+# Deprecated wrappers ------------------------------------------------------
+
+#' @keywords internal
+estimate_parametric_hrf_v2 <- function(...) {
+  .deprecated_version_warning()
+  estimate_parametric_hrf(...)
+}
+
+#' @keywords internal
+estimate_parametric_hrf_v3 <- function(...) {
+  .deprecated_version_warning()
+  estimate_parametric_hrf(...)
+}
+
+#' @keywords internal
+estimate_parametric_hrf_rock_solid <- function(...) {
+  .deprecated_version_warning()
+  estimate_parametric_hrf(...)
+}
+
+#' @keywords internal
+estimate_parametric_hrf_ultimate <- function(...) {
+  .deprecated_version_warning()
+  estimate_parametric_hrf(...)
+}

--- a/tests/testthat/test-ultimate-estimate.R
+++ b/tests/testthat/test-ultimate-estimate.R
@@ -12,7 +12,7 @@ test_that("ultimate estimator runs with basic numeric inputs", {
   event_model <- matrix(0, nrow = n_time, ncol = 1)
   event_model[c(8, 20, 32), 1] <- 1
 
-  fit <- estimate_parametric_hrf_ultimate(
+  fit <- fmriparametric:::estimate_parametric_hrf_ultimate(
     fmri_data = fmri_data,
     event_model = event_model,
     parametric_hrf = "lwu",


### PR DESCRIPTION
## Summary
- remove deprecated HRF exports and add a version constant
- drop runtime `source()` calls in several helpers
- add compatibility wrappers for old HRF API functions
- adjust `test-ultimate-estimate` to use internal wrapper

## Testing
- `devtools::test()` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cad9eea2c832dabc857e0feec2888