### PR TITLE
Add concise docs and getting-started vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^engineering_excellence_demo\.R$
 ^engineering_excellence_final\.R$
 ^run_engineering_demo\.R$
+^docs$

--- a/R/DEPRECATED_VERSIONS.R
+++ b/R/DEPRECATED_VERSIONS.R
@@ -1,25 +1,15 @@
-#' DEPRECATED VERSION NOTICE
+#' Deprecated version notice
 #'
-#' @description
-#' Warning about deprecated function versions
-#'
-#' @details  
-#' The following files contain DEPRECATED versions of estimate_parametric_hrf:
+#' The following files contain obsolete versions of `estimate_parametric_hrf`:
 #' \itemize{
-#'   \item estimate_parametric_hrf_v1_deprecated.R (original Sprint 1 version)
-#'   \item estimate_parametric_hrf_v2.R (Sprint 2 features - NOW MERGED)
-#'   \item estimate_parametric_hrf_v3.R (Sprint 3 features - NOW MERGED)
-#'   \item estimate_parametric_hrf_rock_solid.R (safety features - NOW MERGED)
+#'   \item estimate_parametric_hrf_v1_deprecated.R
+#'   \item estimate_parametric_hrf_v2.R
+#'   \item estimate_parametric_hrf_v3.R
+#'   \item estimate_parametric_hrf_rock_solid.R
 #' }
 #'
-#' ALL features have been consolidated into the ONE TRUE version in:
-#' estimate_parametric_hrf.R
-#'
-#' Having multiple functions with the same name is UNIMPECCABLE.
-#' We have resolved this engineering malpractice.
-#'
-#' DO NOT USE THE DEPRECATED VERSIONS.
-#' They remain only for historical reference.
+#' All features have been merged into `estimate_parametric_hrf.R`. These files
+#' remain for historical reference only.
 #'
 #' @keywords internal
 

--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -1,35 +1,8 @@
-#' Estimate parametric HRF parameters (ULTIMATE IMPECCABLE VERSION)
+#' Estimate parametric HRF parameters
 #'
-#' This is the ONE TRUE implementation of parametric HRF estimation, combining
-#' ALL features from Sprints 1-3 into a single, impeccable interface. Having
-#' multiple functions with the same name is UNIMPECCABLE. This resolves that.
-#'
-#' @details
-#' This function implements a sophisticated multi-stage algorithm:
-#'
-#' **Stage 1: Initialization**
-#' - Data-driven seed selection (if requested)
-#' - K-means clustering for spatial patterns (if K > 0)
-#'
-#' **Stage 2: Core Estimation**
-#' - Single-pass Taylor approximation
-#' - Ridge regularization for stability
-#' - Parameter bounds enforcement
-#'
-#' **Stage 3: Iterative Refinement** (if enabled)
-#' - Global re-centering passes
-#' - Local K-means re-centering
-#' - Convergence monitoring
-#'
-#' **Stage 4: Tiered Refinement** (if enabled)
-#' - Easy voxels: Keep as-is (high R²)
-#' - Moderate voxels: Local re-centering
-#' - Hard voxels: Gauss-Newton optimization
-#'
-#' **Stage 5: Statistical Inference**
-#' - Standard errors via Delta method
-#' - R-squared computation
-#' - Residual analysis
+#' Estimate hemodynamic response function parameters from fMRI time series using
+#' a parametric HRF model. Optional refinement steps improve fits for challenging
+#' voxels.
 #' 
 #' @section Package Options:
 #' Global iterative refinement (Stage 3) is controlled by the option
@@ -71,25 +44,14 @@
 #'   - metadata: Complete analysis metadata
 #'
 #' @examples
-#' \dontrun{
-#' # Basic usage (Sprint 1 features only)
-#' fit <- estimate_parametric_hrf(
-#'   fmri_data = my_data,
-#'   event_model = my_events
-#' )
-#'
-#' # Advanced usage with all features
-#' fit <- estimate_parametric_hrf(
-#'   fmri_data = my_data,
-#'   event_model = my_events,
-#'   theta_seed = "data_driven",
-#'   global_refinement = TRUE,
-#'   kmeans_refinement = TRUE,
-#'   tiered_refinement = "aggressive",
-#'   parallel = TRUE,
-#'   n_cores = 8
-#' )
-#' }
+#' # Simulated quick example
+#' set.seed(1)
+#' fmri_data <- matrix(rnorm(40), nrow = 20, ncol = 2)
+#' events <- matrix(0, nrow = 20, ncol = 1)
+#' events[c(5, 15), 1] <- 1
+#' fit <- estimate_parametric_hrf(fmri_data, events, parametric_hrf = "lwu",
+#'                                verbose = FALSE)
+#' summary(fit)
 #'
 #' @export
 estimate_parametric_hrf <- function(
@@ -144,7 +106,7 @@ estimate_parametric_hrf <- function(
   # Initialize progress tracking if requested
   if (progress && verbose) {
     cat("╔══════════════════════════════════════════════════════════════╗\n")
-    cat("║        PARAMETRIC HRF ESTIMATION (IMPECCABLE VERSION)        ║\n")
+    cat("║             Parametric HRF estimation in progress            ║\n")
     cat("╚══════════════════════════════════════════════════════════════╝\n\n")
   }
   

--- a/R/smart_performance_dispatcher.R
+++ b/R/smart_performance_dispatcher.R
@@ -1,7 +1,6 @@
-#' SMART PERFORMANCE DISPATCHER
-#' 
+#' Smart performance dispatcher
+#'
 #' Automatically selects the optimal algorithm based on problem characteristics.
-#' This is what IMPECCABLE engineering looks like - the code optimizes itself!
 
 #' Smart convolution dispatcher
 #' 

--- a/R/test_compatibility_layer.R
+++ b/R/test_compatibility_layer.R
@@ -1,8 +1,7 @@
-#' TEST COMPATIBILITY LAYER
+#' Test compatibility layer
 #'
 #' Provides backward-compatible functions for existing tests while routing
-#' to our new consolidated implementation. This ensures tests pass while
-#' maintaining our IMPECCABLE consolidation.
+#' to the consolidated implementation.
 
 #' Compatibility wrapper for iterative engine (from v2/v3)
 #' Routes to our new consolidated version with appropriate parameters

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ summary(fit)
 params <- coef(fit)  # Returns tau, sigma, rho for each voxel
 ```
 
+## Documentation
+
+Full function reference and articles are available at
+<https://bbuchsbaum.github.io/fmriparametry>.
+
 ## HRF Models
 
 ### Lag-Width-Undershoot (LWU) Model

--- a/pkgdown.yml
+++ b/pkgdown.yml
@@ -1,0 +1,4 @@
+template:
+  bootstrap: 5
+url: https://bbuchsbaum.github.io/fmriparametry
+destination: docs

--- a/vignettes/getting-started-parametric-hrf.Rmd
+++ b/vignettes/getting-started-parametric-hrf.Rmd
@@ -1,0 +1,50 @@
+---
+title: "Getting started with parametric HRF estimation"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting started with parametric HRF estimation}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Introduction
+
+This short tutorial demonstrates the basic workflow for estimating a parametric
+hemodynamic response function (HRF) from an fMRI time series. The underlying
+algorithm implements the goals outlined in the project proposal: efficient
+voxel-wise estimation of interpretable HRF parameters with optional refinement.
+
+## Simulated example
+
+```{r}
+library(fmriparametric)
+
+# Create a small synthetic dataset
+set.seed(1)
+fmri_data <- matrix(rnorm(40), nrow = 20, ncol = 2)
+
+events <- matrix(0, nrow = 20, ncol = 1)
+events[c(5, 15), 1] <- 1
+
+# Estimate HRF parameters
+fit <- estimate_parametric_hrf(fmri_data, events, parametric_hrf = "lwu",
+                               verbose = FALSE)
+summary(fit)
+```
+
+## Diagnostic plot
+
+```{r, fig.width=6, fig.height=4}
+plot(fit)
+```
+
+The estimated HRF shape and parameter distributions help assess model fit. The
+package design follows the proposal's aim of providing robust, interpretable
+estimates in a few straightforward steps.


### PR DESCRIPTION
## Summary
- reduce exuberant language in roxygen headers
- add quick running example to `estimate_parametric_hrf`
- clarify smart dispatcher and compatibility layer docs
- add pkgdown config and link docs from README
- create `Getting started with parametric HRF estimation` vignette

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cadccdfdc832d9a68845cbb9d2ab9