### PR TITLE
Add integration tests for fmrireg and parallel backend

### DIFF
--- a/tests/testthat/test-parallel-processing.R
+++ b/tests/testthat/test-parallel-processing.R
@@ -1,0 +1,38 @@
+library(testthat)
+
+context("Parallel processing")
+
+# Verify that parallel and sequential fits yield the same results
+
+test_that("Parallel processing matches sequential results", {
+  skip_if_not(parallel::detectCores() > 1, "Single core system")
+  skip_if_not_installed("future")
+
+  set.seed(101)
+  n_time <- 40
+  n_vox <- 6
+  fmri_data <- matrix(rnorm(n_time * n_vox), nrow = n_time, ncol = n_vox)
+  event_model <- matrix(rbinom(n_time, 1, 0.1), ncol = 1)
+
+  fit_seq <- estimate_parametric_hrf(
+    fmri_data = fmri_data,
+    event_model = event_model,
+    parametric_hrf = "lwu",
+    parallel = FALSE,
+    compute_se = FALSE,
+    verbose = FALSE
+  )
+
+  fit_par <- estimate_parametric_hrf(
+    fmri_data = fmri_data,
+    event_model = event_model,
+    parametric_hrf = "lwu",
+    parallel = TRUE,
+    n_cores = 2,
+    compute_se = FALSE,
+    verbose = FALSE
+  )
+
+  expect_equal(coef(fit_seq), coef(fit_par), tolerance = 1e-6)
+  expect_equal(fit_seq$r_squared, fit_par$r_squared, tolerance = 1e-6)
+})

--- a/tests/testthat/test-workflow-validation.R
+++ b/tests/testthat/test-workflow-validation.R
@@ -84,30 +84,30 @@ test_that("Basic workflow with simulated data works", {
 
 test_that("Workflow with fmrireg objects works", {
   skip_if_not_installed("fmrireg")
-  
+
   set.seed(123)
-  
-  # Create fmrireg-compatible objects
+
+  # Create small fmrireg dataset and event model
   n_time <- 100
   n_vox <- 5
-  
-  # Simple synthetic data
-  fmri_data <- matrix(rnorm(n_time * n_vox), nrow = n_time, ncol = n_vox)
-  
-  # Event model with baseline
-  event_model <- cbind(
-    event = rbinom(n_time, 1, 0.1),  # Random events
-    baseline = 1                      # Constant baseline
+
+  bold_mat <- matrix(rnorm(n_time * n_vox), nrow = n_time, ncol = n_vox)
+  fmri_ds <- fmrireg::matrix_dataset(bold_mat, TR = 2, run_length = n_time)
+
+  ev <- fmrireg::event_model(
+    onset = c(20, 40, 60, 80),
+    blockids = rep(1, 4),
+    durations = rep(0, 4)
   )
-  
-  # Should work without errors
+
   fit <- estimate_parametric_hrf(
-    fmri_data = fmri_data,
-    event_model = event_model,
+    fmri_data = fmri_ds,
+    event_model = ev,
     parametric_hrf = "lwu",
-    verbose = FALSE
+    verbose = FALSE,
+    compute_se = FALSE
   )
-  
+
   expect_s3_class(fit, "parametric_hrf_fit")
   expect_equal(nrow(coef(fit)), n_vox)
 })


### PR DESCRIPTION
## Summary
- add full sprint workflow test using real `fmrireg` objects
- add regression test for parallel backend vs sequential
- update workflow validation test to build `fmrireg` datasets

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cae13b1bc832da3b11872ab908d8f