### PR TITLE
Enable fast convolution and parallel backend

### DIFF
--- a/R/performance_optimizations.R
+++ b/R/performance_optimizations.R
@@ -182,13 +182,17 @@
   })["elapsed"]
   
   time_parallel <- system.time({
-    .parametric_engine_parallel(Y[, sample_idx], X, n_cores = 2)
-  })["elapsed"] 
+    pc <- .setup_parallel_backend(n_cores = 2, verbose = FALSE)
+    on.exit(pc$cleanup(), add = TRUE)
+    .parametric_engine_parallel(Y[, sample_idx], X, parallel_config = pc)
+  })["elapsed"]
   
   # Choose best method
   if (time_parallel < 0.8 * time_direct) {
     cores <- min(parallel::detectCores() - 1, ceiling(n_vox / 100))
-    return(.parametric_engine_parallel(Y, X, n_cores = cores))
+    pc <- .setup_parallel_backend(n_cores = cores, verbose = FALSE)
+    on.exit(pc$cleanup(), add = TRUE)
+    return(.parametric_engine_parallel(Y, X, parallel_config = pc))
   } else {
     return(.parametric_engine_direct(Y, X))
   }


### PR DESCRIPTION
## Summary
- connect `.fast_batch_convolution` to the optimized engine
- run the parametric engine with the new parallel backend
- update performance optimizations demo to use backend helpers

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cae1e0fd8832d8cd3d7074879427c