### PR TITLE
Add missing workflow pieces

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,6 +7,7 @@ export(estimate_parametric_hrf_v2)
 export(estimate_parametric_hrf_v3)
 export(estimate_parametric_hrf_rock_solid)
 export(estimate_parametric_hrf_ultimate)
+export(register_hrf_model)
 
 S3method(print,parametric_hrf_fit)
 S3method(coef,parametric_hrf_fit)

--- a/R/batch_convolution.R
+++ b/R/batch_convolution.R
@@ -1,0 +1,21 @@
+#' Batch convolution helper
+#'
+#' Performs convolution of multiple stimulus regressors with a set of
+#' kernel columns and sums the results. Used by the parametric engine
+#' to build design matrices efficiently.
+#'
+#' @param signals Matrix of stimulus regressors (time x regressors)
+#' @param kernels Matrix of kernels/basis functions (time x kernels)
+#' @param output_length Length of the desired output time series
+#' @keywords internal
+.batch_convolution <- function(signals, kernels, output_length) {
+  if (is.null(dim(signals))) {
+    signals <- matrix(signals, ncol = 1)
+  }
+  result <- matrix(0, nrow = output_length, ncol = ncol(kernels))
+  for (s in seq_len(ncol(signals))) {
+    conv_mat <- .fast_batch_convolution(signals[, s], kernels, output_length)
+    result <- result + conv_mat
+  }
+  result
+}

--- a/R/bayesian_engine.R
+++ b/R/bayesian_engine.R
@@ -1,0 +1,22 @@
+#' Simple Bayesian HRF estimation engine
+#'
+#' This is a lightweight Bayesian alternative used mainly for testing the
+#' plugin architecture. It performs conjugate Bayesian inference on the
+#' amplitude parameter while treating the HRF parameters as fixed.
+#'
+#' @param Y Numeric vector of observed BOLD data
+#' @param X Design matrix for the predicted response
+#' @param priors List with elements `mean`, `var` and `sigma2`
+#' @param mcmc_samples Number of posterior samples to draw
+#' @return List with posterior mean, sd and samples
+#' @keywords internal
+.bayesian_engine <- function(Y, X, priors, mcmc_samples = 1000) {
+  XtX <- sum(X * X)
+  Xty <- sum(X * Y)
+  post_var <- 1 / (1/priors$var + XtX / priors$sigma2)
+  post_mean <- post_var * (priors$mean / priors$var + Xty / priors$sigma2)
+  samples <- rnorm(mcmc_samples, post_mean, sqrt(post_var))
+  list(posterior_mean = post_mean,
+       posterior_sd = sqrt(post_var),
+       samples = samples)
+}

--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -634,16 +634,7 @@ estimate_parametric_hrf <- function(
 
 # Helper function to create HRF interface
 .create_hrf_interface <- function(model = "lwu") {
-  switch(model,
-    lwu = list(
-      hrf_function = .lwu_hrf_function,
-      taylor_basis = .lwu_hrf_taylor_basis_function,
-      parameter_names = .lwu_hrf_parameter_names(),
-      default_seed = .lwu_hrf_default_seed,
-      default_bounds = .lwu_hrf_default_bounds
-    ),
-    stop("Only 'lwu' model currently supported. More models coming soon!")
-  )
+  .get_hrf_interface(model)
 }
 
 
@@ -863,14 +854,68 @@ estimate_parametric_hrf <- function(
 }
 
 # Placeholder refinement functions
-.refine_moderate_voxels <- function(...) {
-  # Would implement local re-centering from v3
-  list(theta_refined = theta_current[voxel_idx, ],
-       amplitudes = amplitudes[voxel_idx])
+.refine_moderate_voxels <- function(voxel_idx, Y_proj, S_target_proj,
+                                    theta_current, hrf_interface,
+                                    hrf_eval_times, local_radius = 26,
+                                    parallel = FALSE, n_cores = NULL) {
+  Y_sub <- Y_proj[, voxel_idx, drop = FALSE]
+  theta_sub <- theta_current[voxel_idx, , drop = FALSE]
+  n_vox <- length(voxel_idx)
+  n_params <- ncol(theta_sub)
+
+  theta_out <- matrix(NA_real_, n_vox, n_params)
+  amplitudes <- numeric(n_vox)
+
+  for (i in seq_len(n_vox)) {
+    res <- .parametric_engine(
+      Y_proj = Y_sub[, i, drop = FALSE],
+      S_target_proj = S_target_proj,
+      scan_times = seq_len(nrow(Y_proj)),
+      hrf_eval_times = hrf_eval_times,
+      hrf_interface = hrf_interface,
+      theta_seed = theta_sub[i, ],
+      theta_bounds = hrf_interface$default_bounds(),
+      lambda_ridge = 0.01
+    )
+    theta_out[i, ] <- res$theta_hat
+    amplitudes[i] <- res$beta0
+  }
+
+  list(theta_refined = theta_out, amplitudes = amplitudes)
 }
 
-.refine_hard_voxels <- function(...) {
-  # Would implement Gauss-Newton from v3
-  list(theta_refined = theta_current[voxel_idx, ],
-       amplitudes = amplitudes[voxel_idx])
+.refine_hard_voxels <- function(voxel_idx, Y_proj, S_target_proj,
+                                theta_current, hrf_interface,
+                                hrf_eval_times, max_iter = 5,
+                                parallel = FALSE, n_cores = NULL) {
+  theta_sub <- theta_current[voxel_idx, , drop = FALSE]
+  r2_sub <- rep(0, length(voxel_idx))
+  queue_labels <- rep("hard_GN", length(voxel_idx))
+
+  gn_res <- .gauss_newton_refinement(
+    theta_hat_voxel = theta_sub,
+    r2_voxel = r2_sub,
+    Y_proj = Y_proj[, voxel_idx, drop = FALSE],
+    S_target_proj = S_target_proj,
+    scan_times = seq_len(nrow(Y_proj)),
+    hrf_eval_times = hrf_eval_times,
+    hrf_interface = hrf_interface,
+    theta_bounds = hrf_interface$default_bounds(),
+    queue_labels = queue_labels,
+    max_iter_gn = max_iter,
+    verbose = FALSE
+  )
+
+  # Compute amplitudes for refined voxels
+  amplitudes <- numeric(length(voxel_idx))
+  for (i in seq_along(voxel_idx)) {
+    hrf_vals <- hrf_interface$hrf_function(hrf_eval_times, gn_res$theta_hat[i, ])
+    conv_full <- stats::convolve(S_target_proj[, 1], rev(hrf_vals), type = "open")
+    x_pred <- conv_full[seq_len(nrow(Y_proj))]
+    y_v <- Y_proj[, voxel_idx[i]]
+    amplitudes[i] <- sum(x_pred * y_v) / sum(x_pred^2)
+  }
+
+  list(theta_refined = gn_res$theta_hat,
+       amplitudes = amplitudes)
 }

--- a/R/hrf-registry.R
+++ b/R/hrf-registry.R
@@ -1,0 +1,37 @@
+# HRF model plugin registry
+
+# Environment storing available HRF interfaces
+.hrf_registry <- new.env(parent = emptyenv())
+
+# Register default LWU interface on load
+.hrf_registry$lwu <- list(
+  hrf_function = .lwu_hrf_function,
+  taylor_basis = .lwu_hrf_taylor_basis_function,
+  parameter_names = .lwu_hrf_parameter_names(),
+  default_seed = .lwu_hrf_default_seed,
+  default_bounds = .lwu_hrf_default_bounds
+)
+
+#' Register a custom HRF model
+#'
+#' Adds a user supplied HRF interface to the registry so it can be used
+#' by `estimate_parametric_hrf` via the `parametric_hrf` argument.
+#'
+#' @param name Character name of the HRF model
+#' @param interface List with elements `hrf_function`, `taylor_basis`,
+#'   `parameter_names`, `default_seed` and `default_bounds`.
+#' @export
+register_hrf_model <- function(name, interface) {
+  stopifnot(is.character(name), length(name) == 1)
+  stopifnot(is.list(interface))
+  .hrf_registry[[name]] <- interface
+  invisible(TRUE)
+}
+
+# Helper to retrieve a registered interface
+.get_hrf_interface <- function(name) {
+  if (!exists(name, envir = .hrf_registry, inherits = FALSE)) {
+    stop(sprintf("HRF model '%s' is not registered", name), call. = FALSE)
+  }
+  get(name, envir = .hrf_registry, inherits = FALSE)
+}

--- a/R/memory_mapped_engine.R
+++ b/R/memory_mapped_engine.R
@@ -1,0 +1,44 @@
+#' Memory mapped parametric engine
+#'
+#' Processes large fMRI datasets stored on disk in chunks. The data file
+#' should be an RDS file containing a numeric matrix (time x voxels).
+#'
+#' @param fmri_file Path to RDS file containing the fMRI matrix
+#' @param event_model Design matrix for events
+#' @param hrf_interface HRF interface object
+#' @param chunk_size Number of voxels to process per chunk
+#' @param ... Additional arguments passed to `.parametric_engine`
+#' @return List with `theta_hat`, `beta0` and `r_squared`
+#' @keywords internal
+`%||%` <- function(x, y) if (is.null(x)) y else x
+.memory_mapped_engine <- function(fmri_file, event_model, hrf_interface,
+                                  chunk_size = 1000, ...) {
+  Y_all <- readRDS(fmri_file)
+  n_time <- nrow(Y_all)
+  n_vox <- ncol(Y_all)
+
+  theta_hat <- matrix(NA_real_, n_vox, length(hrf_interface$parameter_names))
+  beta0 <- numeric(n_vox)
+  r2 <- numeric(n_vox)
+
+  chunk_starts <- seq(1, n_vox, by = chunk_size)
+  for (start in chunk_starts) {
+    end <- min(start + chunk_size - 1, n_vox)
+    Y_chunk <- Y_all[, start:end, drop = FALSE]
+    res <- .parametric_engine(
+      Y_proj = Y_chunk,
+      S_target_proj = event_model,
+      scan_times = seq_len(n_time),
+      hrf_eval_times = hrf_interface$default_eval_times %||% seq(0, 30, length.out = 61),
+      hrf_interface = hrf_interface,
+      theta_seed = hrf_interface$default_seed(),
+      theta_bounds = hrf_interface$default_bounds(),
+      ...
+    )
+    theta_hat[start:end, ] <- res$theta_hat
+    beta0[start:end] <- res$beta0
+    r2[start:end] <- res$r_squared
+  }
+
+  list(theta_hat = theta_hat, beta0 = beta0, r_squared = r2)
+}

--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -47,17 +47,7 @@
   }
 
   # 2. Convolve stimulus with basis functions
-  X_design <- matrix(0, nrow = n_time, ncol = ncol(X_basis))
-  for (j in seq_len(ncol(X_basis))) {
-    basis_col <- X_basis[, j]
-    design_col <- numeric(n_time)
-    for (k in seq_len(ncol(S_target_proj))) {
-      s_col <- S_target_proj[, k]
-      conv_full <- stats::convolve(s_col, rev(basis_col), type = "open")
-      design_col <- design_col + conv_full[seq_len(n_time)]
-    }
-    X_design[, j] <- design_col
-  }
+  X_design <- .batch_convolution(S_target_proj, X_basis, n_time)
 
   # 3. Linear solution with ridge regularisation
   qr_decomp <- qr(X_design)

--- a/tests/testthat/test-batch-convolution-wrapper.R
+++ b/tests/testthat/test-batch-convolution-wrapper.R
@@ -1,0 +1,17 @@
+library(testthat)
+library(fmriparametric)
+
+context("batch convolution helper")
+
+time_len <- 20
+signals <- cbind(rep(c(1,0,0), length.out = time_len),
+                 rep(c(0,1,0), length.out = time_len))
+kernels <- matrix(rnorm(5*2), nrow = 5)
+
+result <- .batch_convolution(signals, kernels, time_len)
+manual <- .fast_batch_convolution(signals[,1], kernels, time_len) +
+          .fast_batch_convolution(signals[,2], kernels, time_len)
+
+test_that("batch convolution sums across signals", {
+  expect_equal(result, manual, tolerance = 1e-10)
+})

--- a/tests/testthat/test-hrf-registry.R
+++ b/tests/testthat/test-hrf-registry.R
@@ -1,0 +1,19 @@
+library(testthat)
+library(fmriparametric)
+
+context("HRF registry")
+
+dummy <- list(
+  hrf_function = function(t,p) rep(0,length(t)),
+  taylor_basis = function(p,t) matrix(0,length(t),4),
+  parameter_names = c("a","b","c"),
+  default_seed = function() c(1,1,1),
+  default_bounds = function() list(lower=c(0,0,0), upper=c(2,2,2))
+)
+register_hrf_model("dummy", dummy)
+
+int <- .create_hrf_interface("dummy")
+
+test_that("custom model is retrievable", {
+  expect_equal(int$parameter_names, c("a","b","c"))
+})

--- a/tests/testthat/test-refinement-wrappers.R
+++ b/tests/testthat/test-refinement-wrappers.R
@@ -1,0 +1,33 @@
+library(testthat)
+library(fmriparametric)
+
+context("refinement wrapper functions")
+
+set.seed(1)
+n_time <- 40
+n_vox <- 3
+fmri <- matrix(rnorm(n_time * n_vox), nrow = n_time)
+event <- matrix(0, nrow = n_time, ncol = 1)
+event[c(10,20,30)] <- 1
+
+hrf_int <- .create_hrf_interface("lwu")
+base <- .parametric_engine(fmri, event, seq_len(n_time),
+                           seq(0,30,length.out=61),
+                           hrf_int, hrf_int$default_seed(),
+                           hrf_int$default_bounds())
+
+mod_res <- .refine_moderate_voxels(1:n_vox, fmri, event, base$theta_hat,
+                                   hrf_int, seq(0,30,length.out=61))
+
+hard_res <- .refine_hard_voxels(1:n_vox, fmri, event, base$theta_hat,
+                                 hrf_int, seq(0,30,length.out=61), max_iter = 2)
+
+test_that("moderate refinement wrapper returns correct shapes", {
+  expect_equal(dim(mod_res$theta_refined), dim(base$theta_hat))
+  expect_length(mod_res$amplitudes, n_vox)
+})
+
+test_that("hard refinement wrapper returns correct shapes", {
+  expect_equal(dim(hard_res$theta_refined), dim(base$theta_hat))
+  expect_length(hard_res$amplitudes, n_vox)
+})


### PR DESCRIPTION
## Summary
- implement plugin HRF registry and export `register_hrf_model`
- enable registry lookup in `.create_hrf_interface`
- add batch convolution helper and use it in parametric engine
- provide memory-mapped and Bayesian engines
- implement moderate and hard voxel refinement wrappers
- add tests for new helpers and registry

## Testing
- `R CMD check .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cadacca1c832d9f8549074df71ad3