### PR TITLE
Resolve conflict in estimate_parametric_hrf

### DIFF
--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -626,11 +626,7 @@ estimate_parametric_hrf <- function(
       lambda_ridge = lambda_ridge,
       verbose = FALSE
     )
-##<<<<<<< 65zmk7-codex/fix-merge-conflicts-in-estimate_parametric_hrf.r
-    list(indices = voxel_idx, theta_hat = res$theta_hat, beta0 = res$beta0)
-##=======
     list(list(indices = voxel_idx, theta_hat = res$theta_hat, beta0 = res$beta0))
-##>>>>>>> main
   }
 
   # Run using the generic parallel backend


### PR DESCRIPTION
## Summary
- clean merge markers in estimate_parametric_hrf
- ensure parallel engine returns proper structure

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: Rscript not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cbe4b027c832dbd3aca0cfd8b6959