### PR TITLE
Update NAMESPACE and tests

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -10,6 +10,8 @@ importFrom(digest, digest)
 
 # Main exported function
 export(estimate_parametric_hrf)
+export(register_hrf_model)
+export(get_timing_report)
 
 # S3 methods for parametric_hrf_fit
 S3method(print, parametric_hrf_fit)

--- a/tests/testthat/test-parametric-hrf-fit-methods.R
+++ b/tests/testthat/test-parametric-hrf-fit-methods.R
@@ -5,7 +5,7 @@ context("parametric_hrf_fit S3 methods")
 
 pars <- matrix(rep(1:3, each = 2), nrow = 2, byrow = TRUE)
 amps <- c(1, 2)
-obj <- new_parametric_hrf_fit(
+obj <- fmriparametric:::new_parametric_hrf_fit(
   estimated_parameters = pars,
   amplitudes = amps,
   parameter_names = c("tau", "sigma", "rho"),


### PR DESCRIPTION
## Summary
- regenerate `NAMESPACE` to export `register_hrf_model` and `get_timing_report`
- reference internal constructor in tests

## Testing
- `Rscript -e 'roxygen2::roxygenise()'` *(fails: command not found)*
- `Rscript -e 'devtools::test()'` *(fails: command not found)*
- `R CMD check .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d892439a8832dbd9296ed70fefdb8