### PR TITLE
Fix LWU derivative bounds issue

### DIFF
--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -276,6 +276,10 @@ estimate_parametric_hrf <- function(
       # Ensure theta_center is within bounds before using as seed
       if (!is.null(theta_bounds)) {
         theta_center <- pmax(theta_bounds$lower, pmin(theta_center, theta_bounds$upper))
+        # Stay slightly inside bounds to avoid issues in derivative calculations
+        eps <- 1e-6
+        theta_center <- pmax(theta_bounds$lower + eps,
+                             pmin(theta_center, theta_bounds$upper - eps))
       }
       
       # Re-run engine with new center

--- a/R/hrf-interface-lwu.R
+++ b/R/hrf-interface-lwu.R
@@ -33,6 +33,10 @@
   # Enforce LWU parameter bounds to prevent fmrireg errors
   bounds <- .lwu_hrf_default_bounds()
   params_vector0 <- pmax(bounds$lower, pmin(params_vector0, bounds$upper))
+  # Avoid exact boundary values which can break numerical derivatives
+  eps <- 1e-6
+  params_vector0 <- pmax(bounds$lower + eps,
+                         pmin(params_vector0, bounds$upper - eps))
   
   basis <- fmrireg::hrf_basis_lwu(theta0 = params_vector0,
                                   t = t_hrf_eval,


### PR DESCRIPTION
## Summary
- keep LWU parameters slightly inside valid range before computing Taylor basis
- adjust global refinement to avoid evaluating at exact parameter bounds

## Testing
- `R -q -e "testthat::test_local()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d8da9b7d0832db8761e87855ced60