### PR TITLE
Fix theta_current handling in global refinement

### DIFF
--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -271,6 +271,15 @@ estimate_parametric_hrf <- function(
       r_squared_prev <- r_squared
       
       # Re-center globally with bounds enforcement
+      if (!is.matrix(theta_current) || is.null(dim(theta_current))) {
+        theta_current <- matrix(
+          theta_current,
+          nrow = n_vox,
+          ncol = length(hrf_interface$parameter_names)
+        )
+        colnames(theta_current) <- hrf_interface$parameter_names
+      }
+
       theta_center <- apply(theta_current, 2, median)
       
       # Ensure theta_center is within bounds before using as seed


### PR DESCRIPTION
## Summary
- ensure `theta_current` is a matrix before computing global medians

## Testing
- `R -e "testthat::test_local()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d92426bf4832da67ff197e139758f