### PR TITLE
Fix summary output expectation in integration test

### DIFF
--- a/tests/testthat/test-integration-simple.R
+++ b/tests/testthat/test-integration-simple.R
@@ -62,5 +62,5 @@ test_that("S3 methods work correctly", {
   # Test summary method
   summary_fit <- summary(fit)
   expect_s3_class(summary_fit, "summary.parametric_hrf_fit")
-  expect_output(print(summary_fit), "Parameter Statistics")
+  expect_output(print(summary_fit), "Parameter Estimates")
 })


### PR DESCRIPTION
## Summary
- update integration test to match current summary print output

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d9e41ce2c832d9f55203834a145e3