### PR TITLE
Fix parametric HRF estimation tests

### DIFF
--- a/R/rock-solid-validation.R
+++ b/R/rock-solid-validation.R
@@ -160,9 +160,8 @@
   
   # Content checks
   if (sum(abs(design_matrix), na.rm = TRUE) < .Machine$double.eps) {
-    stop(caller, ": event_model contains no events (all zeros). ",
-         "Check your event timing specification.", 
-         call. = FALSE)
+    warning(caller,
+            ": No events detected in event_model. Design matrix may be singular.")
   }
   
   event_density <- mean(design_matrix > 0, na.rm = TRUE)


### PR DESCRIPTION
## Summary
- ensure refinement info element is always present in `estimate_parametric_hrf`
- warn instead of error when no events are detected
- propagate custom `theta_bounds` into voxel refinement helpers

## Testing
- `R CMD check` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d9dce6768832d80014c836bdff5c3