### PR TITLE
Add argument validation to Bayesian engine

### DIFF
--- a/R/bayesian_engine.R
+++ b/R/bayesian_engine.R
@@ -11,6 +11,43 @@
 #' @return List with posterior mean, sd and samples
 #' @keywords internal
 .bayesian_engine <- function(Y, X, priors, mcmc_samples = 1000) {
+  # Validate Y and X
+  if (!is.numeric(Y) || !is.vector(Y)) {
+    stop(".bayesian_engine: Y must be a numeric vector", call. = FALSE)
+  }
+  if (!is.numeric(X) || !is.vector(X)) {
+    stop(".bayesian_engine: X must be a numeric vector", call. = FALSE)
+  }
+  if (length(Y) != length(X)) {
+    stop(".bayesian_engine: Y and X must have equal length", call. = FALSE)
+  }
+  if (any(!is.finite(Y)) || any(!is.finite(X))) {
+    stop(".bayesian_engine: Y and X must contain only finite values", call. = FALSE)
+  }
+
+  # Validate priors
+  if (!is.list(priors) || !all(c("mean", "var", "sigma2") %in% names(priors))) {
+    stop(".bayesian_engine: priors must be a list with numeric scalars 'mean', 'var', and 'sigma2'", call. = FALSE)
+  }
+  if (!is.numeric(priors$mean) || length(priors$mean) != 1 || !is.finite(priors$mean) ||
+      !is.numeric(priors$var) || length(priors$var) != 1 || !is.finite(priors$var) ||
+      !is.numeric(priors$sigma2) || length(priors$sigma2) != 1 || !is.finite(priors$sigma2)) {
+    stop(".bayesian_engine: priors must contain numeric scalars 'mean', 'var', and 'sigma2'", call. = FALSE)
+  }
+  if (priors$var <= 0) {
+    stop(".bayesian_engine: priors$var must be positive", call. = FALSE)
+  }
+  if (priors$sigma2 <= 0) {
+    stop(".bayesian_engine: priors$sigma2 must be positive", call. = FALSE)
+  }
+
+  # Validate mcmc_samples
+  if (length(mcmc_samples) != 1 || !is.numeric(mcmc_samples) ||
+      !is.finite(mcmc_samples) || mcmc_samples <= 0 ||
+      mcmc_samples != as.integer(mcmc_samples)) {
+    stop(".bayesian_engine: mcmc_samples must be a positive integer", call. = FALSE)
+  }
+
   XtX <- sum(X * X)
   Xty <- sum(X * Y)
   post_var <- 1 / (1/priors$var + XtX / priors$sigma2)

--- a/tests/testthat/test-bayesian-engine.R
+++ b/tests/testthat/test-bayesian-engine.R
@@ -1,0 +1,11 @@
+test_that(".bayesian_engine validates inputs", {
+  y <- 1:10
+  x <- 1:10
+  priors <- list(mean = 0, var = 1, sigma2 = 1)
+
+  expect_error(.bayesian_engine("a", x, priors), "Y must be a numeric vector")
+  expect_error(.bayesian_engine(y, c(1,2), priors), "equal length")
+  expect_error(.bayesian_engine(c(1,2,Inf), c(1,2,3), priors), "finite values")
+  expect_error(.bayesian_engine(y, x, list(mean=0, var=-1, sigma2=1)), "priors\$var must be positive")
+  expect_error(.bayesian_engine(y, x, priors, mcmc_samples = 0), "positive integer")
+})


### PR DESCRIPTION
## Summary
- validate inputs to `.bayesian_engine`
- add regression tests for validation errors

## Testing
- `R -q -e "devtools::test()"` *(fails: R command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0f4884c832d865024e2563927a5