### PR TITLE
Add bayesian engine tests

### DIFF
--- a/tests/testthat/test-bayesian-engine.R
+++ b/tests/testthat/test-bayesian-engine.R
@@ -1,0 +1,34 @@
+context(".bayesian_engine")
+
+test_that("posterior mean and variance match analytic results", {
+  Y <- c(1, 2)
+  X <- c(1, 1)
+  priors <- list(mean = 0, var = 1, sigma2 = 1)
+
+  result <- .bayesian_engine(Y, X, priors)
+
+  expected_var <- 1 / (1/priors$var + sum(X * X) / priors$sigma2)
+  expected_mean <- expected_var * (priors$mean / priors$var + sum(X * Y) / priors$sigma2)
+
+  expect_equal(result$posterior_mean, expected_mean, tolerance = 1e-8)
+  expect_equal(result$posterior_sd^2, expected_var, tolerance = 1e-8)
+  expect_length(result$samples, 1000)
+})
+
+test_that("validation error for mismatched input lengths", {
+  Y <- c(1, 2, 3)
+  X <- c(1, 1)
+  priors <- list(mean = 0, var = 1, sigma2 = 1)
+
+  expect_error(.bayesian_engine(Y, X, priors))
+})
+
+test_that("validation error for invalid prior parameters", {
+  Y <- c(1, 2)
+  X <- c(1, 1)
+  priors_bad_var <- list(mean = 0, var = -1, sigma2 = 1)
+  priors_bad_sigma2 <- list(mean = 0, var = 1, sigma2 = 0)
+
+  expect_error(.bayesian_engine(Y, X, priors_bad_var))
+  expect_error(.bayesian_engine(Y, X, priors_bad_sigma2))
+})


### PR DESCRIPTION
## Summary
- add coverage for `.bayesian_engine`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683ef0f324b0832db736c83f44847f04