### PR TITLE
Add lambda_ridge validation

### DIFF
--- a/R/ridge_linear_solver.R
+++ b/R/ridge_linear_solver.R
@@ -2,7 +2,7 @@
 #'
 #' @param X Design matrix (time x parameters)
 #' @param Y Response matrix (time x voxels)
-#' @param lambda_ridge Ridge penalty
+#' @param lambda_ridge Non-negative numeric ridge penalty (scalar)
 #' @keywords internal
 .ridge_linear_solve <- function(X, Y, lambda_ridge = 0) {
   # Ensure inputs are matrices
@@ -21,10 +21,12 @@
     stop("Y is NULL or empty in .ridge_linear_solve")
   }
   
-  # Ensure lambda is numeric
-  if (!is.numeric(lambda_ridge) || length(lambda_ridge) != 1) {
-    stop("lambda_ridge must be a single numeric value")
-  }
+  # Validate ridge penalty
+  lambda_ridge <- .validate_numeric_param(
+    lambda_ridge, "lambda_ridge",
+    min_val = 0, allow_null = FALSE,
+    caller = ".ridge_linear_solve"
+  )
   
   ridge_linear_solve_cpp(X, Y, lambda_ridge)
 }

--- a/man/dot-ridge_linear_solve.Rd
+++ b/man/dot-ridge_linear_solve.Rd
@@ -11,7 +11,7 @@
 
 \item{Y}{Response matrix (time x voxels)}
 
-\item{lambda_ridge}{Ridge penalty}
+\item{lambda_ridge}{Non-negative numeric ridge penalty (scalar)}
 }
 \description{
 Fast ridge regression solver using RcppEigen and OpenMP

--- a/tests/testthat/test-ridge-linear-solver.R
+++ b/tests/testthat/test-ridge-linear-solver.R
@@ -1,0 +1,24 @@
+library(testthat)
+library(fmriparametric)
+
+context(".ridge_linear_solve input validation")
+
+X <- matrix(rnorm(20), nrow = 5)
+Y <- matrix(rnorm(20), nrow = 5)
+
+# valid call to ensure baseline
+expect_silent(fmriparametric:::.ridge_linear_solve(X, Y, lambda_ridge = 0))
+
+test_that("negative lambda triggers error", {
+  expect_error(
+    fmriparametric:::.ridge_linear_solve(X, Y, lambda_ridge = -1),
+    "lambda_ridge"
+  )
+})
+
+test_that("NA lambda triggers error", {
+  expect_error(
+    fmriparametric:::.ridge_linear_solve(X, Y, lambda_ridge = NA_real_),
+    "lambda_ridge"
+  )
+})


### PR DESCRIPTION
## Summary
- validate `lambda_ridge` via `.validate_numeric_param`
- document that `lambda_ridge` must be non-negative
- test negative or `NA` `lambda_ridge` values

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683ef0e48ff4832d9cc77aa70962dc20