### PR TITLE
Handle invalid memory detection

### DIFF
--- a/R/smart_performance_dispatcher.R
+++ b/R/smart_performance_dispatcher.R
@@ -138,8 +138,9 @@
         mem_available <- mem_total * 0.7  # Use 70% of total
         mem_available
       }, silent = TRUE)
-      
-      if (inherits(mem_info, "try-error")) {
+
+      if (inherits(mem_info, "try-error") ||
+          !is.numeric(mem_info) || is.na(mem_info)) {
         # Fallback: assume 8GB available
         memory_limit <- 8e9
       } else {
@@ -149,6 +150,11 @@
       # Windows fallback
       memory_limit <- 8e9  # 8GB
     }
+  }
+
+  # Validate provided memory_limit before use
+  if (!is.numeric(memory_limit) || is.na(memory_limit)) {
+    memory_limit <- 8e9
   }
   
   use_chunking <- working_memory > memory_limit

--- a/man/dot-smart_memory_decision.Rd
+++ b/man/dot-smart_memory_decision.Rd
@@ -18,5 +18,6 @@ List with chunking recommendation
 }
 \description{
 Decides whether to use chunked processing based on memory constraints
-and dataset size.
+and dataset size. If memory detection fails or \code{memory_limit} is
+\code{NA}, an 8GB limit is assumed.
 }

--- a/tests/testthat/test-memory-fallback.R
+++ b/tests/testthat/test-memory-fallback.R
@@ -1,0 +1,5 @@
+test_that("memory_limit NA triggers fallback to default", {
+  decision <- .smart_memory_decision(100, 100, memory_limit = NA)
+  expect_equal(decision$available_memory_gb, 8)
+  expect_false(decision$use_chunking)
+})


### PR DESCRIPTION
## Summary
- validate `memory_limit` after auto-detection
- fallback to 8GB if the detection returns non-numeric or `NA`
- add regression test for NA memory limit
- document fallback in `.smart_memory_decision` Rd file

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683ef0d82f7c832da0bb4f2f56847274