### PR TITLE
Add input validation in parametric engine

### DIFF
--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -31,6 +31,18 @@
   lambda_ridge = 0.01,
   verbose = FALSE
 ) {
+  # Validate inputs before computing dimensions
+  .validate_input(Y_proj, "Y_proj", type = "matrix")
+  .validate_input(S_target_proj, "S_target_proj", type = "matrix")
+  if (nrow(S_target_proj) != nrow(Y_proj)) {
+    stop(
+      sprintf(
+        "S_target_proj must have %d rows to match Y_proj", nrow(Y_proj)
+      ),
+      call. = FALSE
+    )
+  }
+
   n_time   <- nrow(Y_proj)
   n_vox    <- ncol(Y_proj)
   n_params <- length(theta_seed)

--- a/tests/testthat/test-parametric-engine-validation.R
+++ b/tests/testthat/test-parametric-engine-validation.R
@@ -1,0 +1,77 @@
+test_that(".parametric_engine validates Y_proj input", {
+  hrf_interface <- list(
+    hrf_function = fmriparametric:::.lwu_hrf_function,
+    taylor_basis = fmriparametric:::.lwu_hrf_taylor_basis_function,
+    parameter_names = fmriparametric:::.lwu_hrf_parameter_names(),
+    default_seed = fmriparametric:::.lwu_hrf_default_seed,
+    default_bounds = fmriparametric:::.lwu_hrf_default_bounds
+  )
+  bad_Y <- 1:10
+  good_S <- matrix(0, nrow = 10, ncol = 1)
+  expect_error(
+    fmriparametric:::.parametric_engine(
+      Y_proj = bad_Y,
+      S_target_proj = good_S,
+      scan_times = 1:10,
+      hrf_eval_times = seq(0, 30, length.out = 10),
+      hrf_interface = hrf_interface,
+      theta_seed = c(6, 2.5, 0.35),
+      theta_bounds = list(lower = c(2,1,0), upper = c(12,5,1)),
+      lambda_ridge = 0.01,
+      verbose = FALSE
+    ),
+    "Y_proj"
+  )
+})
+
+test_that(".parametric_engine validates S_target_proj input", {
+  hrf_interface <- list(
+    hrf_function = fmriparametric:::.lwu_hrf_function,
+    taylor_basis = fmriparametric:::.lwu_hrf_taylor_basis_function,
+    parameter_names = fmriparametric:::.lwu_hrf_parameter_names(),
+    default_seed = fmriparametric:::.lwu_hrf_default_seed,
+    default_bounds = fmriparametric:::.lwu_hrf_default_bounds
+  )
+  Y <- matrix(rnorm(20), nrow = 10, ncol = 2)
+  bad_S <- 1:10
+  expect_error(
+    fmriparametric:::.parametric_engine(
+      Y_proj = Y,
+      S_target_proj = bad_S,
+      scan_times = 1:10,
+      hrf_eval_times = seq(0, 30, length.out = 10),
+      hrf_interface = hrf_interface,
+      theta_seed = c(6, 2.5, 0.35),
+      theta_bounds = list(lower = c(2,1,0), upper = c(12,5,1)),
+      lambda_ridge = 0.01,
+      verbose = FALSE
+    ),
+    "S_target_proj"
+  )
+})
+
+test_that(".parametric_engine checks row mismatch", {
+  hrf_interface <- list(
+    hrf_function = fmriparametric:::.lwu_hrf_function,
+    taylor_basis = fmriparametric:::.lwu_hrf_taylor_basis_function,
+    parameter_names = fmriparametric:::.lwu_hrf_parameter_names(),
+    default_seed = fmriparametric:::.lwu_hrf_default_seed,
+    default_bounds = fmriparametric:::.lwu_hrf_default_bounds
+  )
+  Y <- matrix(rnorm(20), nrow = 10, ncol = 2)
+  S <- matrix(0, nrow = 8, ncol = 1)
+  expect_error(
+    fmriparametric:::.parametric_engine(
+      Y_proj = Y,
+      S_target_proj = S,
+      scan_times = 1:10,
+      hrf_eval_times = seq(0, 30, length.out = 10),
+      hrf_interface = hrf_interface,
+      theta_seed = c(6, 2.5, 0.35),
+      theta_bounds = list(lower = c(2,1,0), upper = c(12,5,1)),
+      lambda_ridge = 0.01,
+      verbose = FALSE
+    ),
+    "S_target_proj must have"
+  )
+})


### PR DESCRIPTION
## Summary
- validate `Y_proj` and `S_target_proj` in `.parametric_engine`
- add tests for invalid input to `.parametric_engine`

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0c20040832da92212ede1fc0611