### PR TITLE
Expose epsilon_beta in parametric engine

### DIFF
--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -657,7 +657,8 @@ estimate_parametric_hrf <- function(
 
 .parametric_engine_parallel <- function(Y_proj, S_target_proj, scan_times, hrf_eval_times,
                                        hrf_interface, theta_seed, theta_bounds,
-                                       lambda_ridge = 0.01, parallel_config) {
+                                       lambda_ridge = 0.01, parallel_config,
+                                       epsilon_beta = 1e-6) {
 
   n_vox <- ncol(Y_proj)
   n_params <- length(hrf_interface$parameter_names)
@@ -673,6 +674,7 @@ estimate_parametric_hrf <- function(
       theta_seed = theta_seed,
       theta_bounds = theta_bounds,
       lambda_ridge = lambda_ridge,
+      epsilon_beta = epsilon_beta,
       verbose = FALSE
     )
     list(list(indices = voxel_idx, theta_hat = res$theta_hat, beta0 = res$beta0))

--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -11,6 +11,7 @@
 #' @param theta_seed Numeric vector of starting parameters
 #' @param theta_bounds List with elements `lower` and `upper`
 #' @param lambda_ridge Numeric ridge penalty (default: 0.01)
+#' @param epsilon_beta Small value to avoid division by zero when beta0 is extremely small (default: 1e-6)
 #' @param verbose Logical whether to print progress (default: FALSE)
 #'
 #' @return List with elements:
@@ -29,6 +30,7 @@
   theta_seed,
   theta_bounds,
   lambda_ridge = 0.01,
+  epsilon_beta = 1e-6,
   verbose = FALSE
 ) {
   n_time   <- nrow(Y_proj)
@@ -62,8 +64,8 @@
   beta0 <- coeffs[1, ]
   # Avoid division by zero when beta0 is extremely small
   beta0_safe <- ifelse(
-    abs(beta0) < 1e-6,
-    ifelse(beta0 < 0, -1e-6, 1e-6),
+    abs(beta0) < epsilon_beta,
+    ifelse(beta0 < 0, -epsilon_beta, epsilon_beta),
     beta0
   )
   delta_theta <- coeffs[2:(n_params + 1), , drop = FALSE] /

--- a/man/dot-parametric_engine.Rd
+++ b/man/dot-parametric_engine.Rd
@@ -13,6 +13,7 @@
   theta_seed,
   theta_bounds,
   lambda_ridge = 0.01,
+  epsilon_beta = 1e-06,
   verbose = FALSE
 )
 }
@@ -32,6 +33,8 @@
 \item{theta_bounds}{List with elements \code{lower} and \code{upper}}
 
 \item{lambda_ridge}{Numeric ridge penalty (default: 0.01)}
+
+\item{epsilon_beta}{Small value to avoid division by zero when beta0 is extremely small (default: 1e-06)}
 
 \item{verbose}{Logical whether to print progress (default: FALSE)}
 }


### PR DESCRIPTION
## Summary
- add new argument `epsilon_beta` to `.parametric_engine`
- pass through `epsilon_beta` in `.parametric_engine_parallel`
- document the new argument in Rd files

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683ef0bce510832d81a7cafaa2e6fa20