### PR TITLE
Remove unused scan_times parameter

### DIFF
--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -243,7 +243,6 @@ estimate_parametric_hrf <- function(
     core_result <- process_function(
       Y_proj = inputs$Y_proj,
       S_target_proj = inputs$S_target_proj,
-      scan_times = inputs$scan_times,
       hrf_eval_times = inputs$hrf_eval_times,
       hrf_interface = hrf_interface,
       theta_seed = theta_seed,
@@ -255,7 +254,6 @@ estimate_parametric_hrf <- function(
     core_result <- process_function(
       Y_proj = inputs$Y_proj,
       S_target_proj = inputs$S_target_proj,
-      scan_times = inputs$scan_times,
       hrf_eval_times = inputs$hrf_eval_times,
       hrf_interface = hrf_interface,
       theta_seed = theta_seed,
@@ -328,7 +326,6 @@ estimate_parametric_hrf <- function(
         iter_result <- process_function(
           Y_proj = inputs$Y_proj,
           S_target_proj = inputs$S_target_proj,
-          scan_times = inputs$scan_times,
           hrf_eval_times = inputs$hrf_eval_times,
           hrf_interface = hrf_interface,
           theta_seed = theta_center,
@@ -340,7 +337,6 @@ estimate_parametric_hrf <- function(
         iter_result <- process_function(
           Y_proj = inputs$Y_proj,
           S_target_proj = inputs$S_target_proj,
-          scan_times = inputs$scan_times,
           hrf_eval_times = inputs$hrf_eval_times,
           hrf_interface = hrf_interface,
           theta_seed = theta_center,
@@ -655,7 +651,7 @@ estimate_parametric_hrf <- function(
 
 # MISSING FUNCTION 1: Parallel engine
 
-.parametric_engine_parallel <- function(Y_proj, S_target_proj, scan_times, hrf_eval_times,
+.parametric_engine_parallel <- function(Y_proj, S_target_proj, hrf_eval_times,
                                        hrf_interface, theta_seed, theta_bounds,
                                        lambda_ridge = 0.01, parallel_config) {
 
@@ -667,7 +663,6 @@ estimate_parametric_hrf <- function(
     res <- .parametric_engine(
       Y_proj = Y_proj[, voxel_idx, drop = FALSE],
       S_target_proj = S_target_proj,
-      scan_times = scan_times,
       hrf_eval_times = hrf_eval_times,
       hrf_interface = hrf_interface,
       theta_seed = theta_seed,

--- a/R/parallel-processing.R
+++ b/R/parallel-processing.R
@@ -281,7 +281,6 @@
     local_res <- .parametric_engine(
       Y_proj = prepared_data$Y_proj[, v, drop = FALSE],
       S_target_proj = prepared_data$S_target_proj,
-      scan_times = prepared_data$scan_times,
       hrf_eval_times = prepared_data$hrf_eval_times,
       hrf_interface = hrf_interface,
       theta_seed = theta_local,

--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -12,6 +12,11 @@
 #' @param lambda_ridge Numeric ridge penalty (default: 0.01)
 #' @param verbose Logical whether to print progress (default: FALSE)
 #'
+#' @note
+#' This engine assumes evenly spaced scan times (constant TR).
+#' If acquisition times vary, adjust the stimulus design or
+#' interpolate the data before calling this function.
+#'
 #' @return List with elements:
 #'   - `theta_hat`: Matrix of parameter estimates (voxels x parameters)
 #'   - `beta0`: Numeric vector of amplitudes

--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -5,7 +5,6 @@
 #'
 #' @param Y_proj Numeric matrix of projected BOLD data (timepoints x voxels)
 #' @param S_target_proj Numeric matrix of projected stimulus design (timepoints x regressors)
-#' @param scan_times Numeric vector of scan acquisition times
 #' @param hrf_eval_times Numeric vector of time points for HRF evaluation
 #' @param hrf_interface List with HRF function interface
 #' @param theta_seed Numeric vector of starting parameters
@@ -23,7 +22,6 @@
 .parametric_engine <- function(
   Y_proj,
   S_target_proj,
-  scan_times,
   hrf_eval_times,
   hrf_interface,
   theta_seed,

--- a/R/performance_optimizations.R
+++ b/R/performance_optimizations.R
@@ -94,11 +94,16 @@
     # Load only current chunk
     Y_chunk <- load_fmri_chunk(fmri_file, start_idx, end_idx)
     
-    # Process chunk
+    # Process chunk using default seed and evaluation grid
     result_chunk <- .parametric_engine(
       Y_proj = Y_chunk,
       S_target_proj = event_design,
-      hrf_interface = hrf_interface
+      hrf_eval_times = seq(0, 30, by = 0.5),
+      hrf_interface = hrf_interface,
+      theta_seed = hrf_interface$default_seed(),
+      theta_bounds = hrf_interface$default_bounds(),
+      lambda_ridge = 0.01,
+      verbose = FALSE
     )
     
     # Store results directly to disk

--- a/R/rock-solid-recovery.R
+++ b/R/rock-solid-recovery.R
@@ -129,7 +129,6 @@
       basic_result <- .parametric_engine(
         Y_proj = Y_proj,
         S_target_proj = S_target_proj,
-        scan_times = seq_len(nrow(Y_proj)),
         hrf_eval_times = seq(0, 30, by = 0.5),
         hrf_interface = hrf_interface,
         theta_seed = theta_seed,

--- a/R/single_voxel_sanity_check.R
+++ b/R/single_voxel_sanity_check.R
@@ -38,7 +38,6 @@ single_voxel_sanity_check <- function(
   .parametric_engine(
     Y_proj = Y,
     S_target_proj = S,
-    scan_times = seq_len(length(y)),
     hrf_eval_times = hrf_eval_times,
     hrf_interface = hrf_interface,
     theta_seed = theta_seed,

--- a/engineering_excellence_final.R
+++ b/engineering_excellence_final.R
@@ -93,7 +93,6 @@ timing <- system.time({
   result <- .parametric_engine(
     Y_proj = inputs$Y_proj,
     S_target_proj = inputs$S_target_proj,
-    scan_times = inputs$scan_times,
     hrf_eval_times = inputs$hrf_eval_times,
     hrf_interface = hrf_interface,
     theta_seed = seed_params,
@@ -139,7 +138,6 @@ for (i in seq_along(voxel_counts)) {
     .parametric_engine(
       Y_proj = inputs_subset$Y_proj,
       S_target_proj = inputs_subset$S_target_proj,
-      scan_times = inputs_subset$scan_times,
       hrf_eval_times = inputs_subset$hrf_eval_times,
       hrf_interface = hrf_interface,
       theta_seed = seed_params,

--- a/man/dot-parametric_engine.Rd
+++ b/man/dot-parametric_engine.Rd
@@ -7,7 +7,6 @@
 .parametric_engine(
   Y_proj,
   S_target_proj,
-  scan_times,
   hrf_eval_times,
   hrf_interface,
   theta_seed,
@@ -20,8 +19,6 @@
 \item{Y_proj}{Numeric matrix of projected BOLD data (timepoints x voxels)}
 
 \item{S_target_proj}{Numeric matrix of projected stimulus design (timepoints x regressors)}
-
-\item{scan_times}{Numeric vector of scan acquisition times}
 
 \item{hrf_eval_times}{Numeric vector of time points for HRF evaluation}
 

--- a/man/dot-parametric_engine.Rd
+++ b/man/dot-parametric_engine.Rd
@@ -46,4 +46,5 @@ List with elements:
 Core implementation of the Taylor approximation method for parametric HRF estimation.
 This is the main workhorse function that performs voxel-wise parameter estimation.
 }
+\note{This engine assumes evenly spaced scan times (constant TR). If acquisition times vary, adjust the stimulus design or interpolate the data before calling this function.}
 \keyword{internal}

--- a/tests/test_debug.R
+++ b/tests/test_debug.R
@@ -36,7 +36,6 @@ tryCatch({
   fit <- .parametric_engine(
     Y_proj = Y,
     S_target_proj = S,
-    scan_times = seq(0, (n_time-1)*2, by = 2),
     hrf_eval_times = t_hrf,
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),

--- a/tests/test_realistic_clean.R
+++ b/tests/test_realistic_clean.R
@@ -53,7 +53,6 @@ test_basic_recovery <- function() {
     fit <- .parametric_engine(
       Y_proj = Y,
       S_target_proj = S,
-      scan_times = seq(0, (n_time-1)*2, by = 2),
       hrf_eval_times = t_hrf,
       hrf_interface = hrf_interface,
       theta_seed = c(6, 2.5, 0.35),
@@ -111,7 +110,6 @@ tryCatch({
   fit_empty <- .parametric_engine(
     Y_proj = Y_noise,
     S_target_proj = S_empty,
-    scan_times = seq(0, 49*2, by = 2),
     hrf_eval_times = seq(0, 30, length.out = 61),
     hrf_interface = list(
       hrf_function = .lwu_hrf_function,
@@ -138,7 +136,6 @@ tryCatch({
   fit_single <- .parametric_engine(
     Y_proj = Y_single,
     S_target_proj = S_single,
-    scan_times = seq(0, 99*2, by = 2),
     hrf_eval_times = seq(0, 30, length.out = 61),
     hrf_interface = list(
       hrf_function = .lwu_hrf_function,
@@ -167,7 +164,6 @@ for (n_vox in voxel_counts) {
     fit_bench <- .parametric_engine(
       Y_proj = Y_bench,
       S_target_proj = S_bench,
-      scan_times = seq(0, 99*2, by = 2),
       hrf_eval_times = seq(0, 30, length.out = 61),
       hrf_interface = list(
         hrf_function = .lwu_hrf_function,

--- a/tests/test_realistic_simulation.R
+++ b/tests/test_realistic_simulation.R
@@ -92,7 +92,6 @@ time_basic <- system.time({
   fit_basic <- .parametric_engine(
     Y_proj = data$Y,
     S_target_proj = data$S,
-    scan_times = seq(0, (nrow(data$Y)-1)*2, by = 2),
     hrf_eval_times = data$t_hrf,
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),
@@ -122,7 +121,6 @@ data_clusters <- create_realistic_data(n_time = 150, n_vox = 90, n_clusters = 3,
 fit_clusters <- .parametric_engine(
   Y_proj = data_clusters$Y,
   S_target_proj = data_clusters$S,
-  scan_times = seq(0, (nrow(data_clusters$Y)-1)*2, by = 2),
   hrf_eval_times = data_clusters$t_hrf,
   hrf_interface = hrf_interface,
   theta_seed = c(6, 2.5, 0.35),
@@ -150,7 +148,6 @@ for (i in seq_along(snr_levels)) {
   fit_snr <- .parametric_engine(
     Y_proj = data_snr$Y,
     S_target_proj = data_snr$S,
-    scan_times = seq(0, (nrow(data_snr$Y)-1)*2, by = 2),
     hrf_eval_times = data_snr$t_hrf,
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),
@@ -171,7 +168,6 @@ tryCatch({
   fit_short <- .parametric_engine(
     Y_proj = data_short$Y,
     S_target_proj = data_short$S,
-    scan_times = seq(0, 49*2, by = 2),
     hrf_eval_times = data_short$t_hrf,
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),
@@ -191,7 +187,6 @@ tryCatch({
   fit_empty <- .parametric_engine(
     Y_proj = Y_noise,
     S_target_proj = S_empty,
-    scan_times = seq(0, 99*2, by = 2),
     hrf_eval_times = seq(0, 30, length.out = 61),
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),
@@ -213,7 +208,6 @@ data_iter <- create_realistic_data(n_time = 150, n_vox = 50, snr = 2)
   fit_single <- .parametric_engine(
     Y_proj = data_iter$Y,
     S_target_proj = data_iter$S,
-    scan_times = seq(0, (nrow(data_iter$Y)-1)*2, by = 2),
     hrf_eval_times = data_iter$t_hrf,
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),

--- a/tests/test_with_benchmarks.R
+++ b/tests/test_with_benchmarks.R
@@ -53,7 +53,6 @@ tryCatch({
   fit_engine <- .parametric_engine(
     Y_proj = Y[, 1:n_test_voxels],
     S_target_proj = S[, 1, drop = FALSE],  # Use first regressor
-    scan_times = seq(0, (nrow(Y)-1)*2, by = 2),
     hrf_eval_times = seq(0, 30, length.out = 61),
     hrf_interface = hrf_interface,
     theta_seed = c(6, 2.5, 0.35),
@@ -153,7 +152,6 @@ tryCatch({
   fit_recovery <- .parametric_engine(
     Y_proj = test_data$Y,
     S_target_proj = test_data$S,
-    scan_times = seq(0, 99*2, by = 2),
     hrf_eval_times = seq(0, 30, length.out = 61),
     hrf_interface = list(
       hrf_function = .lwu_hrf_function,
@@ -191,7 +189,6 @@ for (n_vox in c(100, 1000)) {
     fit <- .parametric_engine(
       Y_proj = test_data$Y,
       S_target_proj = test_data$S,
-      scan_times = seq(0, 99*2, by = 2),
       hrf_eval_times = seq(0, 30, length.out = 61),
       hrf_interface = list(
         hrf_function = .lwu_hrf_function,


### PR DESCRIPTION
## Summary
- drop `scan_times` argument from `.parametric_engine`
- update call sites across R code and test scripts
- refresh documentation for `.parametric_engine`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0c3d8ec832db2ba460cbbec1a3f