### PR TITLE
Vectorize theta bound application

### DIFF
--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -74,10 +74,11 @@
 
   # 5. Apply bounds if provided
   if (!is.null(theta_bounds)) {
-    for (j in seq_len(n_params)) {
-      theta_hat[, j] <- pmax(theta_bounds$lower[j],
-                            pmin(theta_hat[, j], theta_bounds$upper[j]))
-    }
+    lower <- matrix(theta_bounds$lower,
+                    nrow = n_vox, ncol = n_params, byrow = TRUE)
+    upper <- matrix(theta_bounds$upper,
+                    nrow = n_vox, ncol = n_params, byrow = TRUE)
+    theta_hat <- pmin(upper, pmax(lower, theta_hat))
   }
 
   if (!is.null(hrf_interface$parameter_names)) {

--- a/tests/test_self_contained.R
+++ b/tests/test_self_contained.R
@@ -79,10 +79,11 @@ simple_engine <- function(Y, S, t_hrf, theta_seed, theta_bounds, lambda = 0.01) 
   theta_hat <- matrix(theta_seed, n_vox, n_params, byrow = TRUE) + t(delta_theta)
   
   # Apply bounds
-  for (j in 1:n_params) {
-    theta_hat[, j] <- pmax(theta_bounds$lower[j], 
-                           pmin(theta_hat[, j], theta_bounds$upper[j]))
-  }
+  lower <- matrix(theta_bounds$lower,
+                  nrow = n_vox, ncol = n_params, byrow = TRUE)
+  upper <- matrix(theta_bounds$upper,
+                  nrow = n_vox, ncol = n_params, byrow = TRUE)
+  theta_hat <- pmin(upper, pmax(lower, theta_hat))
   
   # Calculate R-squared
   Y_pred <- X %*% coeffs


### PR DESCRIPTION
## Summary
- replace per-parameter for loop with vectorized bounds handling in `parametric-engine`
- update self-contained test helper accordingly

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0c04ea4832db9a04caef61e10f2