### PR TITLE
Fix NA handling in Gauss-Newton improvement summary

### DIFF
--- a/R/gauss-newton-refinement.R
+++ b/R/gauss-newton-refinement.R
@@ -240,8 +240,8 @@
     convergence_status = convergence_status,
     iteration_counts = iteration_counts,
     improvement_summary = list(
-      mean_r2_improvement = mean(r2_voxel[idx_hard] - r2_orig[idx_hard]),
-      max_r2_improvement = max(r2_voxel[idx_hard] - r2_orig[idx_hard])
+      mean_r2_improvement = mean(r2_voxel[idx_hard] - r2_orig[idx_hard], na.rm = TRUE),
+      max_r2_improvement = max(r2_voxel[idx_hard] - r2_orig[idx_hard], na.rm = TRUE)
     )
   )
 }


### PR DESCRIPTION
## Summary
- handle NA values when computing improvement summary in `.gauss_newton_refinement`

## Testing
- `R CMD check` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0b2170c832dababff364c738423