### PR TITLE
Handle detectCores edge cases

### DIFF
--- a/R/smart_performance_dispatcher.R
+++ b/R/smart_performance_dispatcher.R
@@ -79,7 +79,13 @@
 .smart_parallel_decision <- function(n_voxels, n_cores = NULL, overhead_per_voxel = 0.001) {
   
   if (is.null(n_cores)) {
-    n_cores <- parallel::detectCores() - 1
+    n_cores <- parallel::detectCores()
+    n_cores <- as.integer(n_cores)
+    if (is.na(n_cores)) {
+      n_cores <- 1L
+    } else {
+      n_cores <- max(1L, n_cores - 1L)
+    }
   }
   
   # Minimum voxels per core to justify parallelization
@@ -89,8 +95,8 @@
   serial_time <- n_voxels * 0.001  # Rough estimate: 1ms per voxel
   parallel_overhead <- overhead_per_voxel * n_voxels
   parallel_time <- (serial_time / n_cores) + parallel_overhead
-  
-  efficiency <- serial_time / parallel_time
+
+  efficiency <- if (parallel_time > 0) serial_time / parallel_time else Inf
   
   use_parallel <- (
     n_voxels > min_voxels_per_core * n_cores &&  # Enough work per core

--- a/tests/testthat/test-smart_parallel_decision.R
+++ b/tests/testthat/test-smart_parallel_decision.R
@@ -1,0 +1,19 @@
+test_that(".smart_parallel_decision handles detectCores edge cases", {
+  # simulate detectCores returning 1
+  testthat::with_mock(
+    `parallel::detectCores` = function(...) 1L,
+    {
+      res <- .smart_parallel_decision(n_voxels = 100)
+      expect_false(res$use_parallel)
+    }
+  )
+
+  # simulate detectCores returning NA
+  testthat::with_mock(
+    `parallel::detectCores` = function(...) NA_integer_,
+    {
+      res <- .smart_parallel_decision(n_voxels = 100)
+      expect_false(res$use_parallel)
+    }
+  )
+})


### PR DESCRIPTION
## Summary
- guard `.smart_parallel_decision()` against NA or single core detection
- avoid divide by zero when computing efficiency
- test detection fallback behavior

## Testing
- `R CMD check .` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0d752cc832d83fda45cc18e42cd