### PR TITLE
Fix platform parallelism in adaptive algorithm selection

### DIFF
--- a/man/dot-adaptive_algorithm_selection.Rd
+++ b/man/dot-adaptive_algorithm_selection.Rd
@@ -19,4 +19,6 @@ List with optimal algorithm and estimated performance
 \description{
 Profiles different approaches and selects the fastest for current hardware
 and data characteristics. Provides optimal performance across problem sizes.
+When profiling parallel execution it uses \code{parallel::parLapply} on
+Windows and \code{parallel::mclapply} on other platforms.
 }


### PR DESCRIPTION
## Summary
- document cross-platform parallel profiling for `.adaptive_algorithm_selection`
- remove unused `n_time` variable
- replace `mclapply` test with platform-aware code using `parLapply` on Windows
- update the Rd documentation

## Testing
- `R CMD build` *(fails: `R` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0ca8390832db48e203ba427e206