### PR TITLE
Fix unused local_radius in refinement

### DIFF
--- a/R/estimate_parametric_hrf.R
+++ b/R/estimate_parametric_hrf.R
@@ -82,7 +82,6 @@ estimate_parametric_hrf <- function(
     r2_hard = 0.3,
     se_low = 0.3,
     se_high = 0.7,
-    local_radius = 26,
     gauss_newton_maxiter = 10
   ),
   # Parallel processing (Sprint 3)
@@ -480,7 +479,6 @@ estimate_parametric_hrf <- function(
         hrf_interface = hrf_interface,
         hrf_eval_times = inputs$hrf_eval_times,
         theta_bounds = theta_bounds,
-        local_radius = refinement_thresholds$local_radius,
         parallel = parallel,
         parallel_config = parallel_config
       )
@@ -882,7 +880,7 @@ estimate_parametric_hrf <- function(
                                     theta_current, r_squared,
                                     hrf_interface, hrf_eval_times,
                                     theta_bounds = NULL,
-                                    local_radius = 1, parallel = FALSE,
+                                    parallel = FALSE,
                                     n_cores = 1) {
 
   if (length(voxel_idx) == 0) {

--- a/man/estimate_parametric_hrf.Rd
+++ b/man/estimate_parametric_hrf.Rd
@@ -24,7 +24,7 @@ estimate_parametric_hrf(
   kmeans_passes = 2,
   tiered_refinement = c("none", "moderate", "aggressive"),
   refinement_thresholds = list(r2_easy = 0.7, r2_hard = 0.3, se_low = 0.3, se_high = 0.7,
-    local_radius = 26, gauss_newton_maxiter = 10),
+    gauss_newton_maxiter = 10),
   parallel = FALSE,
   n_cores = NULL,
   compute_se = TRUE,


### PR DESCRIPTION
## Summary
- remove the unused `local_radius` argument from `.refine_moderate_voxels`
- stop passing `local_radius` from `estimate_parametric_hrf`
- drop `local_radius` from the default threshold list and documentation

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683ef0805408832db8dac9108593c785