### PR TITLE
Improve line search convergence handling

### DIFF
--- a/R/gauss-newton-refinement.R
+++ b/R/gauss-newton-refinement.R
@@ -161,7 +161,17 @@
           break
         }
       }
-      
+
+      # Check if line search produced an update
+      if (all(theta_new == theta_current)) {
+        if (alpha < 1e-6) {
+          convergence_status[i] <- "line_search_failed"
+          break
+        } else {
+          next
+        }
+      }
+
       # Check convergence
       param_change <- sqrt(sum((theta_new - theta_current)^2))
       obj_change <- abs(obj_new - obj_current) / (abs(obj_current) + 1e-10)


### PR DESCRIPTION
## Summary
- handle line search failure inside `.gauss_newton_refinement`
- only check convergence when a step was actually taken

## Testing
- `R -e "testthat::test_local()"` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0af4cb4832dbfa9b4555a05c365