### PR TITLE
Fix padding in smart convolution

### DIFF
--- a/R/smart_performance_dispatcher.R
+++ b/R/smart_performance_dispatcher.R
@@ -28,9 +28,17 @@
   } else {
     # Direct method for small problems
     design_matrix <- matrix(0, output_length, n_kernels)
+    warned <- FALSE
     for (j in seq_len(n_kernels)) {
       conv_full <- convolve(signal, rev(kernels[, j]), type = "open")
-      design_matrix[, j] <- conv_full[seq_len(output_length)]
+      max_len <- min(output_length, length(conv_full))
+      design_matrix[seq_len(max_len), j] <- conv_full[seq_len(max_len)]
+      if (output_length > length(conv_full) && !warned) {
+        warning(
+          "Requested output_length exceeds convolution result; padding with zeros."
+        )
+        warned <- TRUE
+      }
     }
     return(design_matrix)
   }

--- a/man/dot-smart_convolution.Rd
+++ b/man/dot-smart_convolution.Rd
@@ -22,5 +22,6 @@ Smart convolution dispatcher
 }
 \details{
 Automatically chooses between direct convolution and FFT based on problem size.
-This ensures optimal performance across all problem scales.
+This ensures optimal performance across all problem scales. If \code{output_length} is
+greater than the length of the convolution result, the remainder is padded with zeros.
 }

--- a/tests/testthat/test-smart-convolution.R
+++ b/tests/testthat/test-smart-convolution.R
@@ -1,0 +1,8 @@
+test_that(".smart_convolution handles long output_length without NA", {
+  signal <- c(1, 2, 3)
+  kernels <- matrix(c(1, 2), ncol = 1)
+  out_len <- 6
+  result <- .smart_convolution(signal, kernels, out_len)
+  expect_equal(nrow(result), out_len)
+  expect_false(anyNA(result))
+})


### PR DESCRIPTION
## Summary
- handle cases where the requested output length is longer than the convolution result
- document the padding behaviour
- test that `.smart_convolution` does not produce NA values when padded

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0d8dff8832d8c0a5b5a6f781d23