### PR TITLE
Fix comment describing SE metric

### DIFF
--- a/R/refinement-queue.R
+++ b/R/refinement-queue.R
@@ -46,9 +46,9 @@
   # Calculate SE metrics if available
   se_metric <- NULL
   if (!is.null(se_theta_hat_voxel)) {
-    # Use average relative SE across parameters as metric
-    # Relative SE = SE / |parameter estimate|
-    # This is more meaningful than absolute SE
+    # Use average absolute SE across parameters as the metric
+    # se_theta_hat_voxel is expected to contain standard errors for each
+    # parameter, so we take the mean across parameters per voxel
     se_metric <- rowMeans(se_theta_hat_voxel, na.rm = TRUE)
     
     # Cap extreme values


### PR DESCRIPTION
## Summary
- clarify that the SE metric uses average absolute SE

## Testing
- `R -e "testthat::test_local()"` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f11b0a668832dacf480be16e259d1