### PR TITLE
Fix conflict markers in Gauss-Newton refinement

### DIFF
--- a/R/gauss-newton-refinement.R
+++ b/R/gauss-newton-refinement.R
@@ -344,13 +344,7 @@
     dx_dtheta_k <- X_conv[, k + 1]
     
     # Derivative of beta w.r.t. theta_k
-##<<<<<<< codex/add-tolerance-check-for-division-in-calculate_objective_gn-a
     dbeta_dtheta_k <- (sum(dx_dtheta_k * y) - beta * sum(dx_dtheta_k * x_hrf)) / denom
-##=======
-    denom <- denom_amp
-    num <- sum(dx_dtheta_k * y) - 2 * beta * sum(dx_dtheta_k * x_hrf)
-    dbeta_dtheta_k <- num / denom
-##>>>>>>> main
     
     # Full derivative
     jacobian[, k] <- -beta * dx_dtheta_k - dbeta_dtheta_k * x_hrf


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers in `gauss-newton-refinement.R`

## Testing
- `Rscript -e 'testthat::test_local()'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f13199538832dbc614f9e45891f88