### PR TITLE
Fix early return of refinement queue function

### DIFF
--- a/R/refinement-queue.R
+++ b/R/refinement-queue.R
@@ -11,7 +11,10 @@
 #' @return List containing:
 #'   - queue_labels: Character vector of queue assignments
 #'   - queue_summary: Summary statistics for each queue
+#'   - queue_proportions: Proportion of voxels in each queue
+#'   - queue_details: Detailed metrics for each queue
 #'   - refinement_needed: Logical indicating if any refinement is needed
+#'   - classification_criteria: Thresholds used for classification
 #' @keywords internal
 .classify_refinement_queue <- function(
   r2_voxel,
@@ -30,10 +33,15 @@
   queue_labels <- rep("easy", n_vox)
   
   if (!refinement_opts$apply_refinement) {
+    queue_summary <- table(queue_labels)
+    queue_proportions <- prop.table(queue_summary)
     return(list(
       queue_labels = queue_labels,
-      queue_summary = table(queue_labels),
-      refinement_needed = FALSE
+      queue_summary = queue_summary,
+      queue_proportions = queue_proportions,
+      queue_details = list(),
+      refinement_needed = FALSE,
+      classification_criteria = NULL
     ))
   }
   

--- a/man/dot-classify_refinement_queue.Rd
+++ b/man/dot-classify_refinement_queue.Rd
@@ -23,7 +23,10 @@ List containing:
 \itemize{
 \item queue_labels: Character vector of queue assignments
 \item queue_summary: Summary statistics for each queue
+\item queue_proportions: Proportion of voxels in each queue
+\item queue_details: Detailed metrics for each queue
 \item refinement_needed: Logical indicating if any refinement is needed
+\item classification_criteria: Thresholds used for classification
 }
 }
 \description{

--- a/tests/testthat/test-refinement-queue.R
+++ b/tests/testthat/test-refinement-queue.R
@@ -1,0 +1,21 @@
+library(fmriparametric)
+
+test_that(".classify_refinement_queue returns full structure when apply_refinement = FALSE", {
+  r2 <- runif(5)
+  se <- matrix(runif(15), nrow = 5)
+  res <- fmriparametric:::.classify_refinement_queue(
+    r2_voxel = r2,
+    se_theta_hat_voxel = se,
+    refinement_opts = list(apply_refinement = FALSE)
+  )
+  expect_named(res, c(
+    "queue_labels",
+    "queue_summary",
+    "queue_proportions",
+    "queue_details",
+    "refinement_needed",
+    "classification_criteria"
+  ))
+  expect_false(res$refinement_needed)
+  expect_equal(as.character(res$queue_labels), rep("easy", length(r2)))
+})


### PR DESCRIPTION
## Summary
- ensure `.classify_refinement_queue()` always returns the same elements
- document the additional return values
- test behaviour when `apply_refinement = FALSE`

## Testing
- `devtools::test()` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f11ab8114832d97cbba68c8ace884