### PR TITLE
Add SE mismatch check in refinement queue

### DIFF
--- a/R/refinement-queue.R
+++ b/R/refinement-queue.R
@@ -25,7 +25,12 @@
   )
 ) {
   n_vox <- length(r2_voxel)
-  
+
+  if (!is.null(se_theta_hat_voxel) &&
+      nrow(se_theta_hat_voxel) != length(r2_voxel)) {
+    stop("se_theta_hat_voxel must have one row per voxel")
+  }
+
   # Initialize all voxels as "easy" (no refinement needed)
   queue_labels <- rep("easy", n_vox)
   

--- a/tests/testthat/test-refinement-queue.R
+++ b/tests/testthat/test-refinement-queue.R
@@ -1,0 +1,12 @@
+library(fmriparametric)
+
+ test_that(".classify_refinement_queue errors on mismatched SE rows", {
+   r2_vals <- c(0.5, 0.8)
+   se_mat <- matrix(1:6, nrow = 3, ncol = 2)
+   expect_error(
+     fmriparametric:::.classify_refinement_queue(r2_voxel = r2_vals,
+                                                 se_theta_hat_voxel = se_mat),
+     "se_theta_hat_voxel must have one row per voxel"
+   )
+ })
+


### PR DESCRIPTION
## Summary
- validate `se_theta_hat_voxel` rows in `.classify_refinement_queue`
- test that mismatched rows trigger an error

## Testing
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f11ac9154832da836db44cee2f261