### PR TITLE
Add combine_fun option and validation to chunked processing

### DIFF
--- a/R/performance_enhancements.R
+++ b/R/performance_enhancements.R
@@ -79,10 +79,17 @@
 #' @param fmri_data Large fMRI dataset (can be file path or matrix)
 #' @param process_function Function to apply to each chunk
 #' @param chunk_size Number of voxels per chunk
+#' @param combine_fun Function used to combine the chunk results
+#'   (defaults to \code{cbind})
 #' @param progress Show progress bar?
 #' @return Combined results across all chunks
-.chunked_processing <- function(fmri_data, process_function, chunk_size = 1000, 
+.chunked_processing <- function(fmri_data, process_function, chunk_size = 1000,
+                               combine_fun = cbind,
                                progress = TRUE, ...) {
+
+  if (!is.numeric(chunk_size) || chunk_size <= 0) {
+    stop("chunk_size must be a positive integer")
+  }
   
   # Determine total number of voxels
   if (is.character(fmri_data)) {
@@ -133,9 +140,10 @@
     close(pb)
     cat("\nChunked processing complete!\n")
   }
-  
-  # Combine results (implementation depends on result type)
-  return(results_list)
+
+  # Combine results
+  combined <- do.call(combine_fun, results_list)
+  return(combined)
 }
 
 # OPTIMIZATION 4: SIMD-Friendly Vectorization (2x speedup)

--- a/man/dot-chunked_processing.Rd
+++ b/man/dot-chunked_processing.Rd
@@ -9,7 +9,7 @@
   data,
   chunk_size,
   process_fun,
-  combine_fun = rbind,
+  combine_fun = cbind,
   progress = TRUE,
   ...
 )
@@ -18,7 +18,7 @@
   data,
   chunk_size,
   process_fun,
-  combine_fun = rbind,
+  combine_fun = cbind,
   progress = TRUE,
   ...
 )
@@ -31,6 +31,7 @@
 \item{fmri_data}{Large fMRI dataset (can be file path or matrix)}
 
 \item{process_function}{Function to apply to each chunk}
+\item{combine_fun}{Function used to combine the chunk results}
 }
 \value{
 Combined results across all chunks
@@ -38,5 +39,6 @@ Combined results across all chunks
 \description{
 Processes voxels in chunks to handle datasets that don't fit in memory.
 Enables processing of 100k+ voxels without memory issues.
+If \code{chunk_size} is less than or equal to zero, an error is thrown.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- make `.chunked_processing()` check `chunk_size` is positive
- allow choosing result combiner with new `combine_fun` argument
- combine chunk results with `do.call(combine_fun, ...)`
- document new option and behaviour

## Testing
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0ca3644832d9f5ab34bcd615334