### PR TITLE
Add dimension checks in ridge solver

### DIFF
--- a/R/ridge_linear_solver.R
+++ b/R/ridge_linear_solver.R
@@ -12,6 +12,19 @@
   if (!is.matrix(Y)) {
     stop("Y must be a matrix in .ridge_linear_solve")
   }
+
+  # Check that matrices have positive dimensions
+  if (nrow(X) <= 0 || ncol(X) <= 0) {
+    stop("X must have positive dimensions")
+  }
+  if (nrow(Y) <= 0 || ncol(Y) <= 0) {
+    stop("Y must have positive dimensions")
+  }
+
+  # Ensure both matrices have the same number of rows
+  if (nrow(X) != nrow(Y)) {
+    stop("X and Y must have the same number of rows")
+  }
   
   # Check for NULL or empty inputs
   if (is.null(X) || length(X) == 0) {

--- a/tests/testthat/test-ridge-linear-solver.R
+++ b/tests/testthat/test-ridge-linear-solver.R
@@ -1,0 +1,9 @@
+
+# Test that .ridge_linear_solve errors on mismatched row counts
+
+test_that(".ridge_linear_solve errors when X and Y have different rows", {
+  X <- matrix(rnorm(6), nrow = 2, ncol = 3)
+  Y <- matrix(rnorm(9), nrow = 3, ncol = 3)
+  expect_error(fmriparametric:::.ridge_linear_solve(X, Y),
+               "same number of rows")
+})


### PR DESCRIPTION
## Summary
- add dimension validations to `.ridge_linear_solve`
- check same row count between `X` and `Y`
- test for error on mismatched row counts

## Testing
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0e332a4832d9d95676c0c92cb32