### PR TITLE
Validate S_target_proj dimensions

### DIFF
--- a/R/parametric-engine.R
+++ b/R/parametric-engine.R
@@ -35,6 +35,16 @@
   n_vox    <- ncol(Y_proj)
   n_params <- length(theta_seed)
 
+  if (nrow(S_target_proj) != n_time) {
+    stop(
+      sprintf(
+        "S_target_proj has %d rows but expected %d to match Y_proj",
+        nrow(S_target_proj), n_time
+      ),
+      call. = FALSE
+    )
+  }
+
   if (verbose) {
     cat("Parametric engine: ", n_vox, " voxels, ", n_params,
         " parameters\n", sep = "")

--- a/tests/testthat/test-dimension-checks.R
+++ b/tests/testthat/test-dimension-checks.R
@@ -1,0 +1,27 @@
+test_that(".parametric_engine errors on mismatched input sizes", {
+  Y <- matrix(rnorm(20), nrow = 10, ncol = 2)
+  S <- matrix(0, nrow = 9, ncol = 1)
+
+  hrf_interface <- list(
+    hrf_function = .lwu_hrf_function,
+    taylor_basis = .lwu_hrf_taylor_basis_function,
+    parameter_names = .lwu_hrf_parameter_names(),
+    default_seed = .lwu_hrf_default_seed(),
+    default_bounds = .lwu_hrf_default_bounds()
+  )
+
+  expect_error(
+    .parametric_engine(
+      Y_proj = Y,
+      S_target_proj = S,
+      scan_times = seq_len(10),
+      hrf_eval_times = seq(0, 30, length.out = 61),
+      hrf_interface = hrf_interface,
+      theta_seed = hrf_interface$default_seed(),
+      theta_bounds = hrf_interface$default_bounds(),
+      lambda_ridge = 0.01,
+      verbose = FALSE
+    ),
+    "S_target_proj has"
+  )
+})


### PR DESCRIPTION
## Summary
- ensure `.parametric_engine()` checks that `S_target_proj` rows equal the BOLD time points
- add regression test covering mismatch error

## Testing
- `R CMD check` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ef0c15d78832d8aef0e0e85eb26eb