### PR TITLE
Fix chunked processing logic

### DIFF
--- a/man/dot-chunked_processing.Rd
+++ b/man/dot-chunked_processing.Rd
@@ -28,7 +28,7 @@
 
 \item{progress}{Show progress bar?}
 
-\item{fmri_data}{Large fMRI dataset (can be file path or matrix)}
+\item{fmri_data}{fMRI data matrix or other object passed to the processing function. Non\-matrix objects are processed in a single chunk.}
 
 \item{process_function}{Function to apply to each chunk}
 \item{combine_fun}{Function used to combine the chunk results}


### PR DESCRIPTION
## Summary
- better parameter documentation for `.chunked_processing`
- process non-matrix inputs as a single chunk
- improve progress bar logic

## Testing
- `Rscript -e 'print(1)'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f16596510832d88df1e85b75bfec2