### PR TITLE
Update bayesian engine docs for X param

### DIFF
--- a/R/bayesian_engine.R
+++ b/R/bayesian_engine.R
@@ -5,7 +5,7 @@
 #' amplitude parameter while treating the HRF parameters as fixed.
 #'
 #' @param Y Numeric vector of observed BOLD data
-#' @param X Design matrix for the predicted response
+#' @param X Numeric vector representing the predicted response (single-column design)
 #' @param priors List with elements `mean`, `var` and `sigma2`
 #' @param mcmc_samples Number of posterior samples to draw
 #' @return List with posterior mean, sd and samples

--- a/man/dot-bayesian_engine.Rd
+++ b/man/dot-bayesian_engine.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{Y}{Numeric vector of observed BOLD data}
 
-\item{X}{Design matrix for the predicted response}
+\item{X}{Numeric vector representing the predicted response (single-column design)}
 
 \item{priors}{List with elements \code{mean}, \code{var} and \code{sigma2}}
 


### PR DESCRIPTION
## Summary
- clarify `X` parameter description in `.bayesian_engine()`
- sync generated documentation for `.bayesian_engine`

## Testing
- `R -e "devtools::document()"` *(fails: command not found)*
- `R -e "testthat::test_local()"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_683ef0f24004832d9e4a9b810d1ed702