### PR TITLE
Implement predict method for parametric HRF fits

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(coef,parametric_hrf_fit)
 S3method(fitted,parametric_hrf_fit)
+S3method(predict,parametric_hrf_fit)
 S3method(plot,parametric_hrf_fit)
 S3method(print,fmriparametric_error_report)
 S3method(print,parametric_hrf_fit)

--- a/R/parametric-hrf-fit-methods.R
+++ b/R/parametric-hrf-fit-methods.R
@@ -446,3 +446,59 @@ fitted.parametric_hrf_fit <- function(object, Y_proj = NULL, ...) {
   warning("Cannot compute fitted values without residuals")
   NULL
 }
+
+#' Predict BOLD responses from a parametric_hrf_fit
+#'
+#' Generates predicted time series using the estimated HRF parameters and
+#' stimulus design. When `newdata` is `NULL` the function attempts to use the
+#' original design matrix stored in the fit object's metadata.  Predictions are
+#' returned for the selected voxels.
+#'
+#' @param object A `parametric_hrf_fit` object
+#' @param newdata Optional stimulus design matrix in projected space
+#'   (`S_target_proj` format). If `NULL`, uses the design stored in
+#'   `object$metadata$S_target_proj` when available.
+#' @param voxel_indices Integer vector of voxel indices to predict. Defaults to
+#'   all voxels.
+#' @param ... Additional arguments (ignored)
+#' @return Numeric matrix of predicted time series (timepoints x voxels)
+#' @export
+predict.parametric_hrf_fit <- function(object,
+                                       newdata = NULL,
+                                       voxel_indices = NULL,
+                                       ...) {
+  if (is.null(voxel_indices)) {
+    voxel_indices <- seq_len(nrow(object$estimated_parameters))
+  }
+
+  if (is.null(newdata)) {
+    newdata <- object$metadata$S_target_proj
+    if (is.null(newdata)) {
+      stop("newdata must be supplied when original design is unavailable")
+    }
+  }
+
+  if (is.null(dim(newdata))) {
+    newdata <- matrix(newdata, ncol = 1)
+  }
+
+  hrf_eval_times <- object$metadata$hrf_eval_times
+  if (is.null(hrf_eval_times)) {
+    hrf_eval_times <- seq(0, 30, length.out = 61)
+  }
+
+  hrf_interface <- .get_hrf_interface(object$hrf_model)
+  n_time <- nrow(newdata)
+  result <- matrix(NA_real_, nrow = n_time, ncol = length(voxel_indices))
+
+  for (i in seq_along(voxel_indices)) {
+    v <- voxel_indices[i]
+    theta_v <- object$estimated_parameters[v, ]
+    beta0_v <- object$amplitudes[v]
+    hrf_vals <- hrf_interface$hrf_function(hrf_eval_times, theta_v)
+    conv <- .batch_convolution(newdata, matrix(hrf_vals, ncol = 1), n_time)
+    result[, i] <- beta0_v * conv[, 1]
+  }
+
+  result
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,7 +10,8 @@
       coef = coef.parametric_hrf_fit,
       summary = summary.parametric_hrf_fit,
       fitted = fitted.parametric_hrf_fit,
-      residuals = residuals.parametric_hrf_fit
+      residuals = residuals.parametric_hrf_fit,
+      predict = predict.parametric_hrf_fit
     )
     for (generic in names(methods)) {
       registerS3method(generic, "parametric_hrf_fit", methods[[generic]],

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -37,10 +37,17 @@ test_that("S3 methods work for parametric_hrf_fit objects", {
   resid_values <- residuals(fit)
   expect_true(is.matrix(resid_values))
   expect_equal(dim(resid_values), c(20, 5))
-  
+
   # Check that fitted + residuals = original data (approximately)
   reconstructed <- fitted_values + resid_values
   expect_equal(reconstructed, fmri_data, tolerance = 1e-10)
+
+  # Test predict method
+  preds <- predict(fit, newdata = event_design)
+  expect_true(is.matrix(preds))
+  expect_equal(dim(preds), c(20, 5))
+  preds_sub <- predict(fit, newdata = event_design, voxel_indices = 2:3)
+  expect_equal(dim(preds_sub), c(20, 2))
 })
 
 test_that("plot method works for parametric_hrf_fit", {


### PR DESCRIPTION
## Summary
- add new `predict.parametric_hrf_fit` S3 method
- export and register new S3 method
- test predictions via `test-s3-methods.R`

## Testing
- `devtools::test()` *(fails: `R` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f38c5f39c832d8c1b40de780f28e9