### PR TITLE
Update docs on iteration & add convergence tracking

### DIFF
--- a/R/parametric-hrf-fit-methods.R
+++ b/R/parametric-hrf-fit-methods.R
@@ -67,6 +67,11 @@ print.parametric_hrf_fit <- function(x, ...) {
       cat("  K-means clusters:", x$metadata$kmeans_info$n_clusters, "\n")
       cat("  K-means iterations:", x$metadata$kmeans_info$total_iterations, "\n")
     }
+    if (!is.null(x$convergence_info$gauss_newton)) {
+      gn <- x$convergence_info$gauss_newton
+      cat("  Gauss-Newton mean iterations:", round(gn$mean_iterations, 1), "\n")
+      cat("  Hard voxels converged:", gn$n_converged, "/", gn$n_hard, "\n")
+    }
   }
 
   if (!is.null(x$metadata$parallel_info)) {

--- a/man/estimate_parametric_hrf.Rd
+++ b/man/estimate_parametric_hrf.Rd
@@ -90,6 +90,7 @@ Object of class 'parametric_hrf_fit' containing:
 \item standard_errors: Parameter standard errors (if computed)
 \item fit_quality: List with R-squared and other metrics
 \item convergence_info: Detailed convergence information
+Convergence summaries include global iteration counts and, when tiered refinement is used, Gauss-Newton statistics.
 \item refinement_info: Information about refinement strategies applied
 \item metadata: Complete analysis metadata
 }
@@ -104,6 +105,9 @@ voxels.
 Global iterative refinement (Stage 3) is controlled by the option
 \code{fmriparametric.refine_global}. Set to \code{FALSE} to disable global re-centering
 for all calls.
+}
+\section{Iteration and Convergence}{
+The core estimation stage performs a single Taylor approximation pass around the starting parameters. When \code{global_refinement = TRUE}, this seed is iteratively updated for up to \code{global_passes} iterations until the maximum parameter change is below \code{convergence_epsilon}. Optional K-means initialization supplies alternative seeds before this loop. Tiered refinement applies local recentering or Gauss-Newton optimization with its own iteration limits such as \code{refinement_thresholds$gauss_newton_maxiter}.
 }
 
 \examples{


### PR DESCRIPTION
## Summary
- clarify iteration and convergence behaviour in `estimate_parametric_hrf`
- expose k-means iterations in metadata and store Gauss–Newton stats
- print Gauss–Newton summary in convergence section
- document the new behaviour in the man page

## Testing
- `R -q -e devtools::document()` *(fails: `bash: R: command not found`)*
- `R CMD build .` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f38d958a0832db34e8cfece8f5422